### PR TITLE
Fix WebGL example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub fn some_non_wasm_function() -> u32 {
 }
 
 #[cfg(feature = "wasm")]
-#[wasm_bindgen(start)]
+#[wasm_bindgen]
 pub fn start() -> Result<(), JsValue> {
     let document = web_sys::window().unwrap().document().unwrap();
     let canvas = document.get_element_by_id("canvas").unwrap();


### PR DESCRIPTION
Fix is not yet released, but removing the `start` attribute helps...
https://github.com/rustwasm/wasm-bindgen/issues/1267#issuecomment-466738042
https://rustwasm.github.io/wasm-bindgen/reference/attributes/on-rust-exports/start.html?highlight=start#start
![image](https://user-images.githubusercontent.com/1647415/53332394-8e78ca80-38f3-11e9-80a2-78cef03bb783.png)
