### PR TITLE
yage-gl: implement enough for triangle example (native)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,22 +52,6 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
 wee_alloc = { version = "0.4.3", optional = true }
 
-js-sys = { version = "0.3.14", optional = true }
-
-[dependencies.web-sys]
-version = "0.3.14"
-optional = true
-features = [
-  'Document',
-  'Element',
-  'HtmlCanvasElement',
-  'WebGlBuffer',
-  'WebGlRenderingContext',
-  'WebGlProgram',
-  'WebGlShader',
-  'Window',
-]
-
 [dev-dependencies]
 wasm-bindgen-test = "0.2.37"
 

--- a/examples/native-glutin/src/main.rs
+++ b/examples/native-glutin/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     gl::load_with(|ptr| gl_window.context().get_proc_address(ptr) as *const _);
 
     let gl = GL::new();
-    gl.clear_color(0.0, 1.0, 0.0, 1.0);
+    gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
     // let vs = gl.create_shader(glenum::ShaderKind::Vertex);
     // gl.shader_source(vs, VS_SRC);
@@ -43,6 +43,40 @@ fn main() {
     program.use_program();
     check_error!();
 
+    let vb = gl.create_buffer();
+    gl.bind_buffer(glenum::BufferKind::Array as _, Some(vb));
+    gl.buffer_data(
+        glenum::BufferKind::Array as _,
+        &VERTEX_DATA, 
+        glenum::DrawMode::Static as _
+    );
+
+    let vao = gl.create_vertex_array();
+    gl.bind_vertex_array(Some(vao));
+
+    gl.vertex_attrib_pointer(
+        0,
+        2,
+        gl::FLOAT,
+        false,
+        5 * std::mem::size_of::<f32>() as gl::types::GLsizei,
+        0,
+    );
+
+    gl.vertex_attrib_pointer(
+        1,
+        3,
+        gl::FLOAT,
+        false,
+        5 * std::mem::size_of::<f32>() as gl::types::GLsizei,
+        2 * std::mem::size_of::<f32>() as i32,
+    );
+
+    gl.enable_vertex_attrib_array(0);
+    gl.enable_vertex_attrib_array(1);
+
+    check_error!();
+
     let mut running = true;
     while running {
         events_loop.poll_events(|event| {
@@ -62,26 +96,39 @@ fn main() {
         });
 
         gl.clear(glenum::BufferBit::Color);
+        gl.draw_arrays(gl::TRIANGLES, 0, 3);
+
+        // check_error!();
+
         let _ = gl_window.swap_buffers();
     }
 }
 
 
 const VS_SRC: &str = "
-#version 100
+#version 330 core
 precision mediump float;
-attribute vec2 position;
-attribute vec3 color;
-varying vec3 v_color;
+layout (location = 0) in vec2 position;
+layout (location = 1) in vec3 color;
+out vec3 v_color;
 void main() {
     gl_Position = vec4(position, 0.0, 1.0);
     v_color = color;
 }";
 
 const FS_SRC: &str = "
-#version 100
+#version 330 core
 precision mediump float;
-varying vec3 v_color;
+in vec3 v_color;
+out vec4 FragColor;
 void main() {
-    gl_FragColor = vec4(v_color, 1.0);
+    FragColor = vec4(v_color, 1.0);
+    //FragColor = vec4(1.0, 0.0, 0.0, 1.0);
 }";
+
+#[rustfmt::skip]
+static VERTEX_DATA: [f32; 15] = [
+    -0.5, -0.5,  1.0,  0.0,  0.0,
+     0.0,  0.5,  0.0,  1.0,  0.0,
+     0.5, -0.5,  0.0,  0.0,  1.0,
+];

--- a/examples/native-glutin/src/main.rs
+++ b/examples/native-glutin/src/main.rs
@@ -77,6 +77,10 @@ fn main() {
 
     check_error!();
 
+    unsafe {
+        gl::Viewport(0, 0, 300, 200);
+    }
+
     let mut running = true;
     while running {
         events_loop.poll_events(|event| {

--- a/examples/native-glutin/src/main.rs
+++ b/examples/native-glutin/src/main.rs
@@ -1,22 +1,47 @@
 use glutin::GlContext;
 
-use yage::gl::GL;
+use yage::gl::{GL, GlFunctions, check_error, objects::Program};
 use yage::gl::glenum;
 
 fn main() {
     let mut events_loop = glutin::EventsLoop::new();
-    let window = glutin::WindowBuilder::new().with_title("A fantastic window!");
+    let window = glutin::WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_dimensions(glutin::dpi::LogicalSize::new(300.0, 200.0));
     let context = glutin::ContextBuilder::new();
     let gl_window = glutin::GlWindow::new(window, context, &events_loop).unwrap();
 
     let _ = unsafe { gl_window.make_current() };
 
-    println!("Pixel format of the window's GL context: {:?}", gl_window.get_pixel_format());
+    // println!("Pixel format of the window's GL context: {:?}", gl_window.get_pixel_format());
 
     gl::load_with(|ptr| gl_window.context().get_proc_address(ptr) as *const _);
 
     let gl = GL::new();
     gl.clear_color(0.0, 1.0, 0.0, 1.0);
+
+    // let vs = gl.create_shader(glenum::ShaderKind::Vertex);
+    // gl.shader_source(vs, VS_SRC);
+    // gl.compile_shader(vs);
+
+    // let fs = gl.create_shader(glenum::ShaderKind::Fragment);
+    // gl.shader_source(vs, FS_SRC);
+    // gl.compile_shader(fs);
+
+    // let program = gl.create_program();
+
+    // gl.attach_shader(program, vs);
+    // gl.attach_shader(program, fs);
+    // check_error!();
+
+    // gl.link_program(program);
+    // check_error!();
+    // gl.use_program(Some(program));
+
+    let program = Program::from_source(&gl, VS_SRC, FS_SRC, &[]);
+    check_error!();
+    program.use_program();
+    check_error!();
 
     let mut running = true;
     while running {
@@ -40,3 +65,23 @@ fn main() {
         let _ = gl_window.swap_buffers();
     }
 }
+
+
+const VS_SRC: &str = "
+#version 100
+precision mediump float;
+attribute vec2 position;
+attribute vec3 color;
+varying vec3 v_color;
+void main() {
+    gl_Position = vec4(position, 0.0, 1.0);
+    v_color = color;
+}";
+
+const FS_SRC: &str = "
+#version 100
+precision mediump float;
+varying vec3 v_color;
+void main() {
+    gl_FragColor = vec4(v_color, 1.0);
+}";

--- a/yage-gl/Cargo.toml
+++ b/yage-gl/Cargo.toml
@@ -6,18 +6,21 @@ edition = "2018"
 
 [dependencies]
 glenum = "0.1.1"
+log = "0.4.6"
+simplelog = "0.5.3"
 [dependencies.web-sys]
 version = "0.3.14"
 # TODO!: remove unneeded...
 features = [
-  'Document',
-  'Element',
+  # 'Document',
+  # 'Element',
   'HtmlCanvasElement',
   'WebGlBuffer',
   'WebGlRenderingContext',
+  'WebGl2RenderingContext',
   'WebGlProgram',
   'WebGlShader',
-  'Window',
+  # 'Window',
   'console'
 ]
 

--- a/yage-gl/src/gl_native.rs
+++ b/yage-gl/src/gl_native.rs
@@ -15,6 +15,8 @@ impl GL {
 impl GlFunctions for GL {
     type GlShader = gl::types::GLuint;
     type GlProgram = gl::types::GLuint;
+    type GlBuffer = gl::types::GLuint;
+    type GlVertexArray = gl::types::GLuint;
 
     /// specify clear values for the color buffers
     fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {
@@ -81,19 +83,71 @@ impl GlFunctions for GL {
         }
     }
 
-    // TODO!!:
+    fn create_buffer(&self) -> Self::GlBuffer {
+        let mut buf = 0;
+        unsafe { gl::GenBuffers(1, &mut buf); }
+        buf
+    }
 
-    // fn gen_buffers()
-    // fn bind_buffer()
-    // fn buffer_data()
-    // fn gen_vertex_arrays()
-    // fn bind_vertex_array()
+    fn bind_buffer(&self, target: u32, buffer: Option<Self::GlBuffer>) {
+        unsafe {
+            gl::BindBuffer(target, buffer.unwrap_or(0));
+        }
+    }
 
-    // fn get_attrib_location()
-    // fn vertex_attrib_pointer()
-    // fn enable_vertex_attrib_array()
+    fn buffer_data<T>(&self, target: u32, data: &[T], usage: u32) {
+        unsafe {
+            gl::BufferData(
+                target,
+                data.len() as isize,
+                data.as_ptr() as *const std::ffi::c_void,
+                usage
+            );
+        }
+    }
 
-    // fn draw_arrays()
+    fn create_vertex_array(&self) -> Self::GlVertexArray {
+        let mut vao = 0;
+        unsafe { gl::GenVertexArrays(1, &mut vao); }
+        vao
+    }
+
+    fn bind_vertex_array(&self, vertex_array: Option<Self::GlVertexArray>) {
+        unsafe {
+            gl::BindVertexArray(vertex_array.unwrap_or(0));
+        }
+    }
+
+    fn vertex_attrib_pointer(
+        &self,
+        index: u32,
+        size: i32,
+        data_type: u32,
+        normalized: bool,
+        stride: i32,
+        offset: i32,
+    ) {
+        unsafe {
+            gl::VertexAttribPointer(
+                index,
+                size,
+                data_type,
+                normalized as u8,
+                stride,
+                offset as *const std::ffi::c_void,
+            );
+        }
+    }
+
+    fn enable_vertex_attrib_array(&self, index: u32) {
+        unsafe {
+            gl::EnableVertexAttribArray(index);
+        }
+    }
+
+    fn draw_arrays(&self, mode: u32, first: i32, count: i32) {
+        unsafe {
+            gl::DrawArrays(mode as u32, first, count);
+        }
+    }
 }
-
-

--- a/yage-gl/src/gl_native.rs
+++ b/yage-gl/src/gl_native.rs
@@ -99,7 +99,7 @@ impl GlFunctions for GL {
         unsafe {
             gl::BufferData(
                 target,
-                data.len() as isize,
+                (data.len() * 4) as isize,
                 data.as_ptr() as *const std::ffi::c_void,
                 usage
             );

--- a/yage-gl/src/gl_native.rs
+++ b/yage-gl/src/gl_native.rs
@@ -99,7 +99,7 @@ impl GlFunctions for GL {
         unsafe {
             gl::BufferData(
                 target,
-                (data.len() * 4) as isize,
+                (data.len() * std::mem::size_of::<T>()) as isize,
                 data.as_ptr() as *const std::ffi::c_void,
                 usage
             );

--- a/yage-gl/src/gl_native.rs
+++ b/yage-gl/src/gl_native.rs
@@ -1,69 +1,99 @@
-use std::ops::Deref;
-
 use glenum::*;
 
-#[derive(Default)]
-pub struct GL {
-}
+use super::GlFunctions;
 
+#[derive(Default)]
+pub struct GL {}
+
+#[allow(dead_code)]
 impl GL {
     pub fn new() -> GL {
-        GL {
-        }
+        GL {}
     }
+}
+
+impl GlFunctions for GL {
+    type GlShader = gl::types::GLuint;
+    type GlProgram = gl::types::GLuint;
 
     /// specify clear values for the color buffers
-    pub fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {
+    fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {
         unsafe {
             gl::ClearColor(r, g, b, a);
         }
     }
 
     /// clear buffers to preset values
-    pub fn clear(&self, bit: BufferBit) {
+    fn clear(&self, bit: BufferBit) {
         unsafe {
             gl::Clear(bit as _);
         }
     }
 
-    pub fn create_shader(_kind: glenum::ShaderKind) -> Shader {
-        unimplemented!()
+    fn create_shader(&self, kind: glenum::ShaderKind) -> Self::GlShader {
+        unsafe { gl::CreateShader(kind as _) }
     }
 
-    pub fn shader_source(&self, _shader: &Shader, _source: &str) {
-        unimplemented!()
+    fn shader_source(&self, shader: Self::GlShader, source: &str) {
+        unsafe {
+            gl::ShaderSource(
+                shader, 
+                1,
+                &(source.as_ptr() as *const i8), 
+                &(source.len() as i32)
+            );
+        }
+    }
+
+    fn compile_shader(&self, shader: Self::GlShader) {
+        unsafe {
+            gl::CompileShader(shader);
+        }
+    }
+
+    fn delete_shader(&self, shader: Self::GlShader) {
+        unsafe {
+            gl::DeleteShader(shader);
+        }
+    }
+
+    fn create_program(&self) -> Self::GlProgram {
+        unsafe {
+            gl::CreateProgram()
+        }
+    }
+
+    fn attach_shader(&self, program: Self::GlProgram, shader: Self::GlShader) {
+        unsafe {
+            gl::AttachShader(program, shader)
+        }
+    }
+
+    fn link_program(&self, program: Self::GlProgram) {
+        unsafe {
+            gl::LinkProgram(program)
+        }
+    }
+
+    fn use_program(&self, program: Option<Self::GlProgram>) {
+        unsafe {
+            gl::UseProgram(program.unwrap_or(0));
+        }
     }
 
     // TODO!!:
-    // pub fn compile_shader()
-    // pub fn create_program()
-    // pub fn attach_shader()
-    // pub fn link_shader()
-    // pub fn use_program()
 
-    // pub fn gen_buffers()
-    // pub fn bind_buffer()
-    // pub fn buffer_data()
-    // pub fn gen_vertex_arrays()
-    // pub fn bind_vertex_array()
+    // fn gen_buffers()
+    // fn bind_buffer()
+    // fn buffer_data()
+    // fn gen_vertex_arrays()
+    // fn bind_vertex_array()
 
-    // pub fn get_attrib_location()
-    // pub fn vertex_attrib_pointer()
-    // pub fn enable_vertex_attrib_array()
+    // fn get_attrib_location()
+    // fn vertex_attrib_pointer()
+    // fn enable_vertex_attrib_array()
 
-    // pub fn draw_arrays()
+    // fn draw_arrays()
 }
 
-type Reference = u32;
 
-// TODO!!: OpenGL returns an int, WebGL an opaque type... trait + generics?
-// -> https://docs.rs/web-sys/0.3.15/web_sys/struct.WebGl2RenderingContext.html#method.create_shader
-#[derive(Debug)]
-/// an OpenGL shader created with [`GLContext::create_shader`]
-pub struct Shader(pub Reference);
-impl Deref for Shader {
-    type Target = Reference;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}

--- a/yage-gl/src/gl_native.rs
+++ b/yage-gl/src/gl_native.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use glenum::*;
 
 #[derive(Default)]
@@ -22,5 +24,46 @@ impl GL {
         unsafe {
             gl::Clear(bit as _);
         }
+    }
+
+    pub fn create_shader(_kind: glenum::ShaderKind) -> Shader {
+        unimplemented!()
+    }
+
+    pub fn shader_source(&self, _shader: &Shader, _source: &str) {
+        unimplemented!()
+    }
+
+    // TODO!!:
+    // pub fn compile_shader()
+    // pub fn create_program()
+    // pub fn attach_shader()
+    // pub fn link_shader()
+    // pub fn use_program()
+
+    // pub fn gen_buffers()
+    // pub fn bind_buffer()
+    // pub fn buffer_data()
+    // pub fn gen_vertex_arrays()
+    // pub fn bind_vertex_array()
+
+    // pub fn get_attrib_location()
+    // pub fn vertex_attrib_pointer()
+    // pub fn enable_vertex_attrib_array()
+
+    // pub fn draw_arrays()
+}
+
+type Reference = u32;
+
+// TODO!!: OpenGL returns an int, WebGL an opaque type... trait + generics?
+// -> https://docs.rs/web-sys/0.3.15/web_sys/struct.WebGl2RenderingContext.html#method.create_shader
+#[derive(Debug)]
+/// an OpenGL shader created with [`GLContext::create_shader`]
+pub struct Shader(pub Reference);
+impl Deref for Shader {
+    type Target = Reference;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/yage-gl/src/gl_web.rs
+++ b/yage-gl/src/gl_web.rs
@@ -3,6 +3,7 @@ use glenum::*;
 use web_sys::WebGlRenderingContext;
 
 pub struct GL {
+    // TODO: WebGl2RenderingContext is a different class - make type generic?
     context: WebGlRenderingContext,
 }
 

--- a/yage-gl/src/lib.rs
+++ b/yage-gl/src/lib.rs
@@ -24,6 +24,8 @@ use glenum::BufferBit;
 pub trait GlFunctions {
     type GlShader;
     type GlProgram;
+    type GlBuffer;
+    type GlVertexArray;
 
     fn clear_color(&self, r: f32, g: f32, b: f32, a: f32);
     fn clear(&self, bit: BufferBit);
@@ -37,4 +39,24 @@ pub trait GlFunctions {
     fn attach_shader(&self, program: Self::GlProgram, shader: Self::GlShader);
     fn link_program(&self, program: Self::GlProgram);
     fn use_program(&self, program: Option<Self::GlProgram>);
+
+    /// See `gl::GenBuffers`
+    fn create_buffer(&self) -> Self::GlBuffer;
+    fn bind_buffer(&self, target: u32, buffer: Option<Self::GlBuffer>);
+    fn buffer_data<T>(&self, target: u32, data: &[T], usage: u32);
+
+    fn create_vertex_array(&self) -> Self::GlVertexArray;
+    fn bind_vertex_array(&self, vertex_array: Option<Self::GlVertexArray>);
+    fn vertex_attrib_pointer(
+        &self,
+        index: u32,
+        size: i32,
+        data_type: u32,
+        normalized: bool,
+        stride: i32,
+        offset: i32,
+    );
+    fn enable_vertex_attrib_array(&self, index: u32);
+
+    fn draw_arrays(&self, mode: u32, first: i32, count: i32);
 }

--- a/yage-gl/src/lib.rs
+++ b/yage-gl/src/lib.rs
@@ -7,4 +7,34 @@ mod gl;
 pub mod gl;
 
 pub use crate::gl::*;
+
+pub mod objects;
+
+#[macro_use]
+pub mod utils;
+pub use utils::*;
+
 pub use glenum;
+
+use glenum::BufferBit;
+
+/// Trait for all GL functions
+/// Associated types are used to support different handles types in native GL and WebGL
+/// (integers vs opaque JS types like `WebGLShader`)
+pub trait GlFunctions {
+    type GlShader;
+    type GlProgram;
+
+    fn clear_color(&self, r: f32, g: f32, b: f32, a: f32);
+    fn clear(&self, bit: BufferBit);
+
+    fn create_shader(&self, kind: glenum::ShaderKind) -> Self::GlShader;
+    fn shader_source(&self, shader: Self::GlShader, source: &str);
+    fn compile_shader(&self, shader: Self::GlShader);
+    fn delete_shader(&self, shader: Self::GlShader);
+
+    fn create_program(&self) -> Self::GlProgram;
+    fn attach_shader(&self, program: Self::GlProgram, shader: Self::GlShader);
+    fn link_program(&self, program: Self::GlProgram);
+    fn use_program(&self, program: Option<Self::GlProgram>);
+}

--- a/yage-gl/src/objects/mod.rs
+++ b/yage-gl/src/objects/mod.rs
@@ -1,0 +1,2 @@
+pub mod program;
+pub use program::*;

--- a/yage-gl/src/objects/program.rs
+++ b/yage-gl/src/objects/program.rs
@@ -1,0 +1,187 @@
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::fs::File;
+use std::io::Read;
+use std::str;
+
+use gl;
+use gl::types::*;
+
+// use cgmath::{Matrix, Matrix4, Vector3, Vector4};
+// use cgmath::prelude::*;
+
+// use log::{warn, trace};
+
+use crate::{GL, GlFunctions};
+
+// TODO!!!: copied from gltf-viewer (struct Shader) for debugging, barely adapted
+// - native only (-> get rid of direct gl:: calls)
+pub struct Program<'a> {
+    pub id: u32,
+    gl: &'a GL,
+    uniform_location_cache: HashMap<&'static str, i32>
+}
+
+impl<'a> Program<'a> {
+    #[allow(dead_code)]
+    pub fn new(gl: &'a GL, vertex_path: &str, fragment_path: &str, defines: &[String]) -> Program<'a> {
+        // 1. retrieve the vertex/fragment source code from filesystem
+        let mut v_shader_file = File::open(vertex_path).unwrap_or_else(|_| panic!("Failed to open {}", vertex_path));
+        let mut f_shader_file = File::open(fragment_path).unwrap_or_else(|_| panic!("Failed to open {}", fragment_path));
+        let mut vertex_code = String::new();
+        let mut fragment_code = String::new();
+        v_shader_file
+            .read_to_string(&mut vertex_code)
+            .expect("Failed to read vertex shader");
+        f_shader_file
+            .read_to_string(&mut fragment_code)
+            .expect("Failed to read fragment shader");
+
+        Self::from_source(gl, &vertex_code, &fragment_code, defines)
+    }
+
+    // TODO!!: generic GL/ impl Trait?
+    pub fn from_source(gl: &'a GL, vertex_code: &str, fragment_code: &str, defines: &[String]) -> Program<'a> {
+        let mut program = Self {
+            id: 0,
+            gl,
+            uniform_location_cache: HashMap::new()
+        };
+
+        let vertex_code = Self::add_defines(vertex_code, defines);
+        let fragment_code = Self::add_defines(fragment_code, defines);
+
+        // 2. compile shaders
+        unsafe {
+            // vertex shader
+            let vertex = gl.create_shader(glenum::ShaderKind::Vertex);
+            gl.shader_source(vertex, &vertex_code);
+            gl.compile_shader(vertex);
+            program.check_compile_errors(vertex, "VERTEX");
+            // fragment Shader
+            let fragment = gl.create_shader(glenum::ShaderKind::Fragment);
+            gl.shader_source(fragment, &fragment_code);
+            gl.compile_shader(fragment);
+            program.check_compile_errors(fragment, "FRAGMENT");
+            // shader Program
+            let id = gl.create_program();
+            gl.attach_shader(id, vertex);
+            gl.attach_shader(id, fragment);
+            gl.link_program(id);
+            program.check_compile_errors(id, "PROGRAM");
+            // delete the shaders as they're linked into our program now and no longer necessary
+            gl.delete_shader(vertex);
+            gl.delete_shader(fragment);
+            program.id = id;
+        }
+
+        program
+    }
+
+    fn add_defines(source: &str, defines: &[String]) -> String {
+        // insert preprocessor defines after #version if exists
+        // (#version must occur before any other statement in the program)
+        let defines = defines.iter()
+            .map(|define| format!("#define {}", define))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut lines: Vec<_> = source.lines().collect();
+        if let Some(version_line) = lines.iter().position(|l| l.starts_with("#version")) {
+            lines.insert(version_line+1, &defines);
+        }
+        else {
+            lines.insert(0, &defines);
+        }
+        lines.join("\n")
+    }
+
+    /// activate the shader
+    /// ------------------------------------------------------------------------
+    pub fn use_program(&self) {
+        self.gl.use_program(Some(self.id))
+    }
+
+    /// utility uniform functions
+    /// ------------------------------------------------------------------------
+    #[allow(dead_code)]
+    pub unsafe fn set_bool(&self, location: i32, value: bool) {
+        gl::Uniform1i(location, value as i32);
+    }
+    /// ------------------------------------------------------------------------
+    pub unsafe fn set_int(&self, location: i32, value: i32) {
+        gl::Uniform1i(location, value);
+    }
+    /// ------------------------------------------------------------------------
+    pub unsafe fn set_float(&self, location: i32, value: f32) {
+        gl::Uniform1f(location, value);
+    }
+    /// ------------------------------------------------------------------------
+    // pub unsafe fn set_vector3(&self, location: i32, value: &Vector3<f32>) {
+    //     gl::Uniform3fv(location, 1, value.as_ptr());
+    // }
+    // /// ------------------------------------------------------------------------
+    // pub unsafe fn set_vector4(&self, location: i32, value: &Vector4<f32>) {
+    //     gl::Uniform4fv(location, 1, value.as_ptr());
+    // }
+    /// ------------------------------------------------------------------------
+    pub unsafe fn set_vec2(&self, location: i32, x: f32, y: f32) {
+        gl::Uniform2f(location, x, y);
+    }
+    /// ------------------------------------------------------------------------
+    pub unsafe fn set_vec3(&self, location: i32, x: f32, y: f32, z: f32) {
+        gl::Uniform3f(location, x, y, z);
+    }
+    /// ------------------------------------------------------------------------
+    // pub unsafe fn set_mat4(&self, location: i32, mat: &Matrix4<f32>) {
+    //     gl::UniformMatrix4fv(location, 1, gl::FALSE, mat.as_ptr());
+    // }
+
+    /// get uniform location with caching
+    pub unsafe fn uniform_location(&mut self, name: &'static str) -> i32 {
+        if let Some(loc) = self.uniform_location_cache.get(name) {
+            return *loc;
+        }
+
+        let c_name = CString::new(name).unwrap();
+        let loc = gl::GetUniformLocation(self.id, c_name.as_ptr());
+        if loc == -1 {
+            // TODO!: trace!
+            println!("uniform '{}' unknown for shader {}", name, self.id);
+        }
+        self.uniform_location_cache.insert(name, loc);
+        loc
+    }
+
+    /// utility function for checking shader compilation/linking errors.
+    /// ------------------------------------------------------------------------
+    unsafe fn check_compile_errors(&self, shader: u32, type_: &str) {
+        let mut success = i32::from(gl::FALSE);
+        let mut info_log = Vec::with_capacity(1024);
+        info_log.set_len(1024 - 1); // subtract 1 to skip the trailing null character
+        if type_ != "PROGRAM" {
+            gl::GetShaderiv(shader, gl::COMPILE_STATUS, &mut success);
+            let log_type = if success == i32::from(gl::TRUE) { "WARNING" } else { "ERROR" };
+            let mut length = 0;
+            gl::GetShaderInfoLog(shader, 1024, &mut length, info_log.as_mut_ptr() as *mut GLchar);
+            if length == 0 { return }
+            panic!("{}::SHADER_COMPILATION_{} of type: {}\n{}",
+                      log_type, log_type,
+                      type_,
+                      str::from_utf8(&info_log[0..length as usize]).unwrap());
+
+        } else {
+            gl::GetProgramiv(shader, gl::LINK_STATUS, &mut success);
+            let log_type = if success == i32::from(gl::TRUE) { "WARNING" } else { "ERROR" };
+            let mut length = 0;
+            gl::GetProgramInfoLog(shader, 1024, &mut length, info_log.as_mut_ptr() as *mut GLchar);
+            if length == 0 { return }
+            // TODO!: warn!
+            println!("{}::PROGRAM_LINKING_{} of type: {}\n{}",
+                      log_type, log_type,
+                      type_,
+                      str::from_utf8(&info_log[0..length as usize]).unwrap());
+        }
+
+    }
+}
+

--- a/yage-gl/src/utils.rs
+++ b/yage-gl/src/utils.rs
@@ -1,0 +1,31 @@
+#[cfg(not(target_arch = "wasm32"))]
+pub fn gl_check_error(file: &str, line: u32) -> u32 {
+    unsafe {
+        let mut error_code = gl::GetError();
+        while error_code != gl::NO_ERROR {
+            let error = match error_code {
+                gl::INVALID_ENUM => "INVALID_ENUM",
+                gl::INVALID_VALUE => "INVALID_VALUE",
+                gl::INVALID_OPERATION => "INVALID_OPERATION",
+                gl::STACK_OVERFLOW => "STACK_OVERFLOW",
+                gl::STACK_UNDERFLOW => "STACK_UNDERFLOW",
+                gl::OUT_OF_MEMORY => "OUT_OF_MEMORY",
+                gl::INVALID_FRAMEBUFFER_OPERATION => "INVALID_FRAMEBUFFER_OPERATION",
+                _ => "unknown GL error code"
+            };
+
+            println!("{} | {} ({})", error, file, line);
+
+            error_code = gl::GetError();
+        }
+        error_code
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[macro_export]
+macro_rules! check_error {
+    () => (
+        $crate::utils::gl_check_error(file!(), line!())
+    )
+}


### PR DESCRIPTION
* `examples/native-glutin` ~_should_~ now renders a triangle (~but no GL errors and no triangle...~)
  - src of triangle: https://github.com/tomaka/glutin/blob/master/glutin_examples/examples/support/mod.rs
* native only