### PR TITLE
yage-gl: essential GL methods for glTF rendering (native)

### DIFF
--- a/examples/native-glutin/src/main.rs
+++ b/examples/native-glutin/src/main.rs
@@ -77,9 +77,7 @@ fn main() {
 
     check_error!();
 
-    unsafe {
-        gl::Viewport(0, 0, 300, 200);
-    }
+    gl.viewport(0, 0, 300, 200);
 
     let mut running = true;
     while running {
@@ -127,7 +125,6 @@ in vec3 v_color;
 out vec4 FragColor;
 void main() {
     FragColor = vec4(v_color, 1.0);
-    //FragColor = vec4(1.0, 0.0, 0.0, 1.0);
 }";
 
 #[rustfmt::skip]

--- a/yage-gl/Cargo.toml
+++ b/yage-gl/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 glenum = "0.1.1"
 log = "0.4.6"
-simplelog = "0.5.3"
 cgmath = "0.17.0"
 [dependencies.web-sys]
 version = "0.3.14"
@@ -27,6 +26,7 @@ features = [
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 gl = "0.11.0"
+simplelog = "0.5.3"
 
 [target.wasm32-unknown-unknown.dependencies]
 js-sys = "0.3.14"

--- a/yage-gl/Cargo.toml
+++ b/yage-gl/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 glenum = "0.1.1"
 log = "0.4.6"
 simplelog = "0.5.3"
+cgmath = "0.17.0"
 [dependencies.web-sys]
 version = "0.3.14"
 # TODO!: remove unneeded...

--- a/yage-gl/src/gl_native.rs
+++ b/yage-gl/src/gl_native.rs
@@ -34,6 +34,12 @@ impl GlFunctions for GL {
         }
     }
 
+    fn viewport(&self, x: i32, y: i32, width: i32, height: i32) {
+        unsafe {
+            gl::Viewport(x, y, width, height);
+        }
+    }
+
     fn create_shader(&self, kind: glenum::ShaderKind) -> Self::GlShader {
         unsafe { gl::CreateShader(kind as _) }
     }
@@ -61,6 +67,34 @@ impl GlFunctions for GL {
         }
     }
 
+    fn get_shader_parameter(&self, shader: Self::GlShader, param: u32) -> i32 {
+        let mut result = 0;
+        unsafe {
+            gl::GetShaderiv(shader, param, &mut result);
+        }
+        result
+    }
+
+    fn get_shader_info_log(&self, shader: Self::GlShader) -> String {
+        let mut length = self.get_shader_parameter(shader, gl::INFO_LOG_LENGTH);
+        if length > 0 {
+            let mut log = String::with_capacity(length as usize);
+            log.extend(std::iter::repeat('\0').take(length as usize));
+                unsafe {
+                    gl::GetShaderInfoLog(
+                    shader,
+                    length,
+                    &mut length,
+                    (&log[..]).as_ptr() as *mut gl::types::GLchar,
+                );
+            }
+            log.truncate(length as usize);
+            log
+        } else {
+            "".into()
+        }
+    }
+
     fn create_program(&self) -> Self::GlProgram {
         unsafe {
             gl::CreateProgram()
@@ -76,6 +110,34 @@ impl GlFunctions for GL {
     fn link_program(&self, program: Self::GlProgram) {
         unsafe {
             gl::LinkProgram(program)
+        }
+    }
+
+    fn get_program_parameter(&self, program: Self::GlProgram, param: u32) -> i32 {
+        let mut result = 0;
+        unsafe {
+            gl::GetProgramiv(program, param, &mut result);
+        }
+        result
+    }
+
+    fn get_program_info_log(&self, program: Self::GlProgram) -> String {
+        let mut length = self.get_program_parameter(program, gl::INFO_LOG_LENGTH);
+        if length > 0 {
+            let mut log = String::with_capacity(length as usize);
+            log.extend(std::iter::repeat('\0').take(length as usize));
+                unsafe {
+                    gl::GetProgramInfoLog(
+                    program,
+                    length,
+                    &mut length,
+                    (&log[..]).as_ptr() as *mut gl::types::GLchar,
+                );
+            }
+            log.truncate(length as usize);
+            log
+        } else {
+            "".into()
         }
     }
 
@@ -242,6 +304,16 @@ impl GlFunctions for GL {
     fn tex_parameteri(&self, target: u32, parameter: u32, value: i32) {
         unsafe {
             gl::TexParameteri(target, parameter, value);
+        }
+    }
+
+    fn get_uniform_location(
+        &self,
+        program: Self::GlProgram,
+        name: &str,
+    ) -> Self::GlUniformLocation {
+        unsafe {
+            gl::GetUniformLocation(program, name.as_ptr() as *const i8) as i32
         }
     }
 

--- a/yage-gl/src/gl_native.rs
+++ b/yage-gl/src/gl_native.rs
@@ -17,6 +17,8 @@ impl GlFunctions for GL {
     type GlProgram = gl::types::GLuint;
     type GlBuffer = gl::types::GLuint;
     type GlVertexArray = gl::types::GLuint;
+    type GlTexture = gl::types::GLuint;
+    type GlUniformLocation = gl::types::GLint;
 
     /// specify clear values for the color buffers
     fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {
@@ -150,4 +152,139 @@ impl GlFunctions for GL {
             gl::DrawArrays(mode as u32, first, count);
         }
     }
+
+    fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32) {
+        unsafe {
+            gl::DrawElements(
+                mode as u32,
+                count,
+                element_type as u32,
+                offset as *const std::ffi::c_void,
+            );
+        }
+    }
+
+    fn enable(&self, param: u32) {
+        unsafe {
+            gl::Enable(param);
+        }
+    }
+
+    fn disable(&self, param: u32) {
+        unsafe {
+            gl::Disable(param);
+        }
+    }
+
+    fn point_size(&self, size: f32) {
+        unsafe {
+            gl::PointSize(size);
+        }
+    }
+
+    fn active_texture(&self, unit: u32) {
+        unsafe {
+            gl::ActiveTexture(unit);
+        }
+    }
+
+    fn bind_texture(&self, target: u32, texture: Option<Self::GlTexture>) {
+       unsafe {
+           gl::BindTexture(target, texture.unwrap_or(0));
+       } 
+    }
+
+    fn blend_func(&self, src: u32, dst: u32) {
+        unsafe {
+            gl::BlendFunc(src, dst);
+        }
+    }
+
+    fn create_texture(&self) -> Self::GlTexture {
+        let mut tex = 0;
+        unsafe { gl::GenTextures(1, &mut tex); }
+        tex
+    }
+
+    fn tex_image_2d(
+        &self,
+        target: u32,
+        level: i32,
+        internal_format: i32,
+        width: i32,
+        height: i32,
+        border: i32,
+        format: u32,
+        ty: u32,
+        pixels: Option<&[u8]>,
+    ) {
+        unsafe {
+            gl::TexImage2D(
+                target,
+                level,
+                internal_format,
+                width,
+                height,
+                border,
+                format,
+                ty,
+                pixels.map(|p| p.as_ptr()).unwrap_or(std::ptr::null()) as *const std::ffi::c_void,
+            );
+        }
+    }
+
+    fn generate_mipmap(&self) {
+        unsafe {
+            gl::GenerateMipmap(gl::TEXTURE_2D);
+        }
+    }
+
+    fn tex_parameteri(&self, target: u32, parameter: u32, value: i32) {
+        unsafe {
+            gl::TexParameteri(target, parameter, value);
+        }
+    }
+
+    fn uniform_1i(&self, location: Self::GlUniformLocation, x: i32) {
+        unsafe {
+            gl::Uniform1i(location, x);
+        }
+    }
+
+    fn uniform_1f(&self, location: Self::GlUniformLocation, x: f32) {
+        unsafe {
+            gl::Uniform1f(location, x);
+        }
+    }
+
+    fn uniform_3fv(&self, location: Self::GlUniformLocation, x: &[f32; 3]) {
+        unsafe {
+            gl::Uniform3fv(location, 1, x.as_ptr());
+        }
+    }
+
+    fn uniform_4fv(&self, location: Self::GlUniformLocation, x: &[f32; 4]) {
+        unsafe {
+            gl::Uniform4fv(location, 1, x.as_ptr());
+        }
+    }
+
+    fn uniform_2f(&self, location: Self::GlUniformLocation, x: f32, y: f32) {
+        unsafe {
+            gl::Uniform2f(location, x, y);
+        }
+    }
+
+    fn uniform_3f(&self, location: Self::GlUniformLocation, x: f32, y: f32, z: f32) {
+        unsafe {
+            gl::Uniform3f(location, x, y, z);
+        }
+    }
+
+    fn uniform_matrix_4fv(&self, location: Self::GlUniformLocation, mat: &[[f32; 4]; 4]) {
+        unsafe {
+            gl::UniformMatrix4fv(location, 1, gl::FALSE, mat.as_ptr() as _);
+        }
+    }
+
 }

--- a/yage-gl/src/gl_native.rs
+++ b/yage-gl/src/gl_native.rs
@@ -1,7 +1,5 @@
 use glenum::*;
 
-use super::GlFunctions;
-
 #[derive(Default)]
 pub struct GL {}
 
@@ -12,7 +10,7 @@ impl GL {
     }
 }
 
-impl GlFunctions for GL {
+impl super::GlFunctions for GL {
     type GlShader = gl::types::GLuint;
     type GlProgram = gl::types::GLuint;
     type GlBuffer = gl::types::GLuint;

--- a/yage-gl/src/gl_web.rs
+++ b/yage-gl/src/gl_web.rs
@@ -13,14 +13,207 @@ impl GL {
             context
         }
     }
+}
+
+#[allow(dead_code)]
+impl super::GlFunctions for GL {
+    type GlShader = u32;
+    type GlProgram = u32;
+    type GlBuffer = u32;
+    type GlVertexArray = u32;
+    type GlTexture = u32;
+    type GlUniformLocation = i32;
 
     /// specify clear values for the color buffers
-    pub fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {
+    fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {
         self.context.clear_color(r, g, b, a);
     }
 
-        /// clear buffers to preset values
-    pub fn clear(&self, bit: BufferBit) {
+    /// clear buffers to preset values
+    fn clear(&self, bit: BufferBit) {
         self.context.clear(bit as _);
+    }
+
+    fn viewport(&self, x: i32, y: i32, width: i32, height: i32) {
+        unimplemented!()
+    }
+
+    fn create_shader(&self, kind: glenum::ShaderKind) -> Self::GlShader {
+        unimplemented!()
+    }
+
+    fn shader_source(&self, shader: Self::GlShader, source: &str) {
+        unimplemented!()
+    }
+
+    fn compile_shader(&self, shader: Self::GlShader) {
+        unimplemented!()
+    }
+
+    fn delete_shader(&self, shader: Self::GlShader) {
+        unimplemented!()
+    }
+
+    fn get_shader_parameter(&self, shader: Self::GlShader, param: u32) -> i32 {
+        unimplemented!()
+    }
+
+    fn get_shader_info_log(&self, shader: Self::GlShader) -> String {
+        unimplemented!()
+    }
+
+    fn create_program(&self) -> Self::GlProgram {
+        unimplemented!()
+    }
+
+    fn attach_shader(&self, program: Self::GlProgram, shader: Self::GlShader) {
+        unimplemented!()
+    }
+
+    fn link_program(&self, program: Self::GlProgram) {
+        unimplemented!()
+    }
+
+    fn get_program_parameter(&self, program: Self::GlProgram, param: u32) -> i32 {
+        unimplemented!()
+    }
+
+    fn get_program_info_log(&self, program: Self::GlProgram) -> String {
+        unimplemented!()
+    }
+
+    fn use_program(&self, program: Option<Self::GlProgram>) {
+        unimplemented!()
+    }
+
+    fn create_buffer(&self) -> Self::GlBuffer {
+        unimplemented!()
+    }
+
+    fn bind_buffer(&self, target: u32, buffer: Option<Self::GlBuffer>) {
+        unimplemented!()
+    }
+
+    fn buffer_data<T>(&self, target: u32, data: &[T], usage: u32) {
+        unimplemented!()
+    }
+
+    fn create_vertex_array(&self) -> Self::GlVertexArray {
+        unimplemented!()
+    }
+
+    fn bind_vertex_array(&self, vertex_array: Option<Self::GlVertexArray>) {
+        unimplemented!()
+    }
+
+    fn vertex_attrib_pointer(
+        &self,
+        index: u32,
+        size: i32,
+        data_type: u32,
+        normalized: bool,
+        stride: i32,
+        offset: i32,
+    ) {
+        unimplemented!()
+    }
+
+    fn enable_vertex_attrib_array(&self, index: u32) {
+        unimplemented!()
+    }
+
+    fn draw_arrays(&self, mode: u32, first: i32, count: i32) {
+        unimplemented!()
+    }
+
+    fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32) {
+        unimplemented!()
+    }
+
+    fn enable(&self, param: u32) {
+        unimplemented!()
+    }
+
+    fn disable(&self, param: u32) {
+        unimplemented!()
+    }
+
+    fn point_size(&self, size: f32) {
+        unimplemented!()
+    }
+
+    fn active_texture(&self, unit: u32) {
+        unimplemented!()
+    }
+
+    fn bind_texture(&self, target: u32, texture: Option<Self::GlTexture>) {
+        unimplemented!()
+    }
+
+    fn blend_func(&self, src: u32, dst: u32) {
+        unimplemented!()
+    }
+
+    fn create_texture(&self) -> Self::GlTexture {
+        unimplemented!()
+    }
+
+    fn tex_image_2d(
+        &self,
+        target: u32,
+        level: i32,
+        internal_format: i32,
+        width: i32,
+        height: i32,
+        border: i32,
+        format: u32,
+        ty: u32,
+        pixels: Option<&[u8]>,
+    ) {
+        unimplemented!()
+    }
+
+    fn generate_mipmap(&self) {
+        unimplemented!()
+    }
+
+    fn tex_parameteri(&self, target: u32, parameter: u32, value: i32) {
+        unimplemented!()
+    }
+
+    fn get_uniform_location(
+        &self,
+        program: Self::GlProgram,
+        name: &str,
+    ) -> Self::GlUniformLocation {
+        unimplemented!()
+    }
+
+    fn uniform_1i(&self, location: Self::GlUniformLocation, x: i32) {
+        unimplemented!()
+    }
+
+    fn uniform_1f(&self, location: Self::GlUniformLocation, x: f32) {
+        unimplemented!()
+    }
+
+    fn uniform_3fv(&self, location: Self::GlUniformLocation, x: &[f32; 3]) {
+        unimplemented!()
+    }
+
+    fn uniform_4fv(&self, location: Self::GlUniformLocation, x: &[f32; 4]) {
+        unimplemented!()
+    }
+
+    fn uniform_2f(&self, location: Self::GlUniformLocation, x: f32, y: f32) {
+        unimplemented!()
+    }
+
+    fn uniform_3f(&self, location: Self::GlUniformLocation, x: f32, y: f32, z: f32) {
+        unimplemented!()
+    }
+
+    fn uniform_matrix_4fv(&self, location: Self::GlUniformLocation, mat: &[[f32; 4]; 4]) {
+        unimplemented!()
     }
 }

--- a/yage-gl/src/lib.rs
+++ b/yage-gl/src/lib.rs
@@ -26,6 +26,8 @@ pub trait GlFunctions {
     type GlProgram;
     type GlBuffer;
     type GlVertexArray;
+    type GlTexture;
+    type GlUniformLocation;
 
     fn clear_color(&self, r: f32, g: f32, b: f32, a: f32);
     fn clear(&self, bit: BufferBit);
@@ -59,4 +61,48 @@ pub trait GlFunctions {
     fn enable_vertex_attrib_array(&self, index: u32);
 
     fn draw_arrays(&self, mode: u32, first: i32, count: i32);
+    fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32);
+
+    fn enable(&self, param: u32);
+    fn disable(&self, param: u32);
+
+    fn point_size(&self, size: f32);
+
+    fn active_texture(&self, unit: u32);
+    fn bind_texture(&self, target: u32, texture: Option<Self::GlTexture>);
+
+    fn blend_func(&self, src: u32, dst: u32);
+
+    fn create_texture(&self) -> Self::GlTexture;
+
+    #[allow(clippy::too_many_arguments)]
+    fn tex_image_2d(
+        &self,
+        target: u32,
+        level: i32,
+        internal_format: i32,
+        width: i32,
+        height: i32,
+        border: i32,
+        format: u32,
+        ty: u32,
+        pixels: Option<&[u8]>,
+    );
+
+    fn generate_mipmap(&self);
+
+    fn tex_parameteri(&self, target: u32, parameter: u32, value: i32);
+
+    fn uniform_1i(&self, location: Self::GlUniformLocation, x: i32);
+    fn uniform_1f(&self, location: Self::GlUniformLocation, x: f32);
+    fn uniform_3fv(&self, location: Self::GlUniformLocation, x: &[f32; 3]);
+    fn uniform_4fv(&self, location: Self::GlUniformLocation, x: &[f32; 4]);
+    fn uniform_2f(&self, location: Self::GlUniformLocation, x: f32, y: f32);
+    fn uniform_3f(&self, location: Self::GlUniformLocation, x: f32, y: f32, z: f32);
+    fn uniform_matrix_4fv(&self, location: Self::GlUniformLocation, value: &[[f32; 4]; 4]);
+
+    // TODO!!: required calls for gltf:
+    // shader -> GetUniformLocation
+    // framebuffer
+    // viewer - polygonmode, pixelstorei, readpixels, viewport
 }

--- a/yage-gl/src/lib.rs
+++ b/yage-gl/src/lib.rs
@@ -21,6 +21,11 @@ use glenum::BufferBit;
 /// Trait for all GL functions
 /// Associated types are used to support different handles types in native GL and WebGL
 /// (integers vs opaque JS types like `WebGLShader`)
+/// Please refer to the OpenGL/WebGL documentation for details about each
+/// function (hint: http://docs.gl/).
+/// Some functions are named differently in WebGL than in OpenGL - we use the WebGL nomenclature
+/// since they are clearer (e.g. create_buffer for gl::GenBuffers, 
+/// get_shader_parameter for gl::GetShaderiv)
 pub trait GlFunctions {
     type GlShader;
     type GlProgram;
@@ -32,17 +37,24 @@ pub trait GlFunctions {
     fn clear_color(&self, r: f32, g: f32, b: f32, a: f32);
     fn clear(&self, bit: BufferBit);
 
+    fn viewport(&self, x: i32, y: i32, width: i32, height: i32);
+
     fn create_shader(&self, kind: glenum::ShaderKind) -> Self::GlShader;
     fn shader_source(&self, shader: Self::GlShader, source: &str);
     fn compile_shader(&self, shader: Self::GlShader);
     fn delete_shader(&self, shader: Self::GlShader);
+    /// Named after the WebGL function. See `gl::GetShaderiv` for OpenGL.
+    fn get_shader_parameter(&self, shader: Self::GlShader, param: u32) -> i32;
+    fn get_shader_info_log(&self, shader: Self::GlShader) -> String;
 
     fn create_program(&self) -> Self::GlProgram;
     fn attach_shader(&self, program: Self::GlProgram, shader: Self::GlShader);
     fn link_program(&self, program: Self::GlProgram);
+    fn get_program_parameter(&self, program: Self::GlProgram, param: u32) -> i32;
+    fn get_program_info_log(&self, program: Self::GlProgram) -> String;
     fn use_program(&self, program: Option<Self::GlProgram>);
 
-    /// See `gl::GenBuffers`
+    /// Named after the WebGL function. See `gl::GenBuffers` for OpenGL.
     fn create_buffer(&self) -> Self::GlBuffer;
     fn bind_buffer(&self, target: u32, buffer: Option<Self::GlBuffer>);
     fn buffer_data<T>(&self, target: u32, data: &[T], usage: u32);
@@ -93,6 +105,12 @@ pub trait GlFunctions {
 
     fn tex_parameteri(&self, target: u32, parameter: u32, value: i32);
 
+    fn get_uniform_location(
+        &self,
+        program: Self::GlProgram,
+        name: &str,
+    ) -> Self::GlUniformLocation;
+
     fn uniform_1i(&self, location: Self::GlUniformLocation, x: i32);
     fn uniform_1f(&self, location: Self::GlUniformLocation, x: f32);
     fn uniform_3fv(&self, location: Self::GlUniformLocation, x: &[f32; 3]);
@@ -101,8 +119,7 @@ pub trait GlFunctions {
     fn uniform_3f(&self, location: Self::GlUniformLocation, x: f32, y: f32, z: f32);
     fn uniform_matrix_4fv(&self, location: Self::GlUniformLocation, value: &[[f32; 4]; 4]);
 
-    // TODO!!: required calls for gltf:
-    // shader -> GetUniformLocation
+    // TODO!: "optional" methods from gltf-viewer (mostly for screenshots, headless):
     // framebuffer
-    // viewer - polygonmode, pixelstorei, readpixels, viewport
+    // viewer - polygonmode, pixelstorei, readpixels 
 }


### PR DESCRIPTION
Implements all essential methods used in my gltf-viewer (i.e. ignoring screenshots/headless mode).
Expect minor API changes when implementing the WebGL version (=> `GlFunctions` trait).