### PR TITLE
Bump dependencies and fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: cargo
 matrix:
   include:
 
-  # Builds with wasm-pack.
+  # Builds with wasm-pack and native.
   - rust: stable
     env: RUST_BACKTRACE=1
     addons:
@@ -23,6 +23,8 @@ matrix:
       # in any of our parent dirs is problematic.
       - mv Cargo.toml Cargo.toml.tmpl
       - cd testing
+      - cargo build
+      - cargo test
       - wasm-pack build
       - wasm-pack test --chrome --firefox --headless
 
@@ -40,9 +42,6 @@ matrix:
       - cd testing
       - cargo check
       - cargo check --target wasm32-unknown-unknown
-      - cargo check                                 --no-default-features
-      - cargo check --target wasm32-unknown-unknown --no-default-features
-      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
       - cargo check --target wasm32-unknown-unknown --no-default-features --features "console_error_panic_hook wee_alloc"
 
   # Builds on beta.
@@ -59,9 +58,6 @@ matrix:
       - cd testing
       - cargo check
       - cargo check --target wasm32-unknown-unknown
-      - cargo check                                 --no-default-features
-      - cargo check --target wasm32-unknown-unknown --no-default-features
-      - cargo check                                 --no-default-features --features console_error_panic_hook
       - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
       # Note: no enabling the `wee_alloc` feature here because it requires
       # nightly for now.

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,7 @@ matrix:
       - cargo check --target wasm32-unknown-unknown
       - cargo check                                 --no-default-features
       - cargo check --target wasm32-unknown-unknown --no-default-features
-      - cargo check                                 --no-default-features --features console_error_panic_hook
       - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
-      - cargo check                                 --no-default-features --features "console_error_panic_hook wee_alloc"
       - cargo check --target wasm32-unknown-unknown --no-default-features --features "console_error_panic_hook wee_alloc"
 
   # Builds on beta.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = ["yage-core", "yage-gl", "yage-glutin", "yage-web", "yage-gltf"]
 exclude = ["examples/native-glutin", "examples/rust-webpack", "examples/native-azul"]
 
 [dependencies]
-cfg-if = "0.1.6"
+cfg-if = "0.1.7"
 
 yage-core = { path = "yage-core", version = "0.0.1" }
 yage-gl = { path = "yage-gl", version = "0.0.1" }
@@ -37,7 +37,7 @@ yage-glutin = { path = "yage-glutin", version = "0.0.1" }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 yage-web = { path = "yage-web", version = "0.0.1" }
 
-wasm-bindgen = "0.2.37"
+wasm-bindgen = "0.2.40"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -53,7 +53,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 wee_alloc = { version = "0.4.3", optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.37"
+wasm-bindgen-test = "0.2.40"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/examples/native-glutin/Cargo.toml
+++ b/examples/native-glutin/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 glutin = "0.19.0"
-gl = "0.11.0"
+gl = "0.12.0"
 yage = { path = "../../" }

--- a/yage-gl/Cargo.toml
+++ b/yage-gl/Cargo.toml
@@ -9,7 +9,7 @@ glenum = "0.1.1"
 log = "0.4.6"
 cgmath = "0.17.0"
 [dependencies.web-sys]
-version = "0.3.14"
+version = "0.3.17"
 # TODO!: remove unneeded...
 features = [
   # 'Document',
@@ -25,10 +25,10 @@ features = [
 ]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-gl = "0.11.0"
+gl = "0.12.0"
 simplelog = "0.5.3"
 
 [target.wasm32-unknown-unknown.dependencies]
-js-sys = "0.3.14"
-wasm-bindgen = "0.2.37"
+js-sys = "0.3.17"
+wasm-bindgen = "0.2.40"
 

--- a/yage-gltf/Cargo.toml
+++ b/yage-gltf/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Benjamin Wasty <benjamin.wasty@cginternals.com>", "Stefan Buschmann 
 edition = "2018"
 
 [dependencies]
-gltf = { version = "0.11.2", features = ["names"] }
+gltf = { version = "0.11.3", features = ["names"] }


### PR DESCRIPTION
Held back: glutin (0.20 has breaking changes (window/context creation) and the unreleased 0.21 seems to change window creation again).