### PR TITLE
yage-gl: More functions, some objects

### DIFF
--- a/yage-gl/Cargo.toml
+++ b/yage-gl/Cargo.toml
@@ -20,6 +20,7 @@ features = [
   'WebGlTexture',
   'WebGlFramebuffer',
   'WebGlRenderbuffer',
+  'WebGlTransformFeedback',
 ]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/yage-gl/Cargo.toml
+++ b/yage-gl/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 glenum = "0.1.1"
 log = "0.4.6"
 cgmath = "0.17.0"
-[dependencies.web-sys]
+
+[target.wasm32-unknown-unknown.dependencies.web-sys]
 version = "0.3.17"
 features = [
   'WebGl2RenderingContext',

--- a/yage-gl/src/functions/gl_native.rs
+++ b/yage-gl/src/functions/gl_native.rs
@@ -426,9 +426,9 @@ impl super::GlFunctions for GL {
         }
     }
 
-    fn generate_mipmap(&self) {
+    fn generate_mipmap(&self, target: u32) {
         unsafe {
-            gl::GenerateMipmap(gl::TEXTURE_2D);
+            gl::GenerateMipmap(target);
         }
     }
 
@@ -705,11 +705,19 @@ impl super::GlFunctions for GL {
         unsafe { gl::Flush() }
     }
 
-    fn create_transform_feedback(&self) -> Self::GlTransformFeedback {
-        let mut feedback = 0;
+    fn get_parameter_i32(&self, parameter: u32) -> i32 {
+        let mut value = 0;
         unsafe {
-            gl::GenTransformFeedbacks(1, &mut feedback);
+            gl::GetIntegerv(parameter, &mut value);
         }
-        feedback
+        value
     }
+
+    // fn create_transform_feedback(&self) -> Self::GlTransformFeedback {
+    //     let mut feedback = 0;
+    //     unsafe {
+    //         gl::GenTransformFeedbacks(1, &mut feedback);
+    //     }
+    //     feedback
+    // }
 }

--- a/yage-gl/src/functions/gl_native.rs
+++ b/yage-gl/src/functions/gl_native.rs
@@ -1,7 +1,5 @@
 use std::ffi::c_void;
 
-use glenum::*;
-
 #[derive(Default)]
 pub struct GL {}
 
@@ -660,9 +658,9 @@ impl super::GlFunctions for GL {
         }
     }
 
-    fn clear(&self, bit: BufferBit) {
+    fn clear(&self, mask: u32) {
         unsafe {
-            gl::Clear(bit as _);
+            gl::Clear(mask);
         }
     }
 

--- a/yage-gl/src/functions/gl_native.rs
+++ b/yage-gl/src/functions/gl_native.rs
@@ -102,6 +102,12 @@ impl super::GlFunctions for GL {
         unsafe { gl::AttachShader(*program, *shader) }
     }
 
+    fn detach_shader(&self, program: &Self::GlProgram, shader: &Self::GlShader) {
+        unsafe {
+            gl::DetachShader(*program, *shader);
+        }
+    }
+
     fn link_program(&self, program: &Self::GlProgram) {
         unsafe { gl::LinkProgram(*program) }
     }
@@ -223,6 +229,12 @@ impl super::GlFunctions for GL {
         }
     }
 
+    fn vertex_attrib_divisor(&self, index: u32, divisor: u32) {
+        unsafe {
+            gl::VertexAttribDivisor(index, divisor);
+        }
+    }
+
     fn enable_vertex_attrib_array(&self, index: u32) {
         unsafe {
             gl::EnableVertexAttribArray(index);
@@ -241,6 +253,12 @@ impl super::GlFunctions for GL {
         }
     }
 
+    fn draw_arrays_instanced(&self, mode: u32, first: i32, count: i32, instance_count: i32) {
+        unsafe {
+            gl::DrawArraysInstanced(mode, first, count, instance_count);
+        }
+    }
+
     fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32) {
         unsafe {
             gl::DrawElements(
@@ -248,6 +266,25 @@ impl super::GlFunctions for GL {
                 count,
                 element_type as u32,
                 offset as *const std::ffi::c_void,
+            );
+        }
+    }
+
+    fn draw_elements_instanced(
+        &self,
+        mode: u32,
+        count: i32,
+        element_type: u32,
+        offset: i32,
+        instance_count: i32,
+    ) {
+        unsafe {
+            gl::DrawElementsInstanced(
+                mode,
+                count,
+                element_type,
+                offset as *const std::ffi::c_void,
+                instance_count,
             );
         }
     }
@@ -285,6 +322,12 @@ impl super::GlFunctions for GL {
     fn blend_func(&self, src: u32, dst: u32) {
         unsafe {
             gl::BlendFunc(src, dst);
+        }
+    }
+
+    fn blend_func_separate(&self, src_rgb: u32, dst_rgb: u32, src_alpha: u32, dst_alpha: u32) {
+        unsafe {
+            gl::BlendFuncSeparate(src_rgb, dst_rgb, src_alpha, dst_alpha);
         }
     }
 
@@ -510,5 +553,61 @@ impl super::GlFunctions for GL {
                 data.as_mut_ptr() as _,
             );
         }
+    }
+
+    fn depth_func(&self, func: u32) {
+        unsafe {
+            gl::DepthFunc(func);
+        }
+    }
+
+    fn depth_mask(&self, value: bool) {
+        unsafe {
+            gl::DepthMask(value as _);
+        }
+    }
+
+    fn stencil_func(&self, func: u32, reference: i32, mask: u32) {
+        unsafe {
+            gl::StencilFunc(func, reference, mask);
+        }
+    }
+
+    fn stencil_mask(&self, mask: u32) {
+        unsafe {
+            gl::StencilMask(mask);
+        }
+    }
+
+    fn stencil_op(&self, stencil_fail: u32, depth_fail: u32, pass: u32) {
+        unsafe {
+            gl::StencilOp(stencil_fail, depth_fail, pass);
+        }
+    }
+
+    fn cull_face(&self, value: u32) {
+        unsafe {
+            gl::CullFace(value);
+        }
+    }
+
+    fn scissor(&self, x: i32, y: i32, width: i32, height: i32) {
+        unsafe {
+            gl::Scissor(x, y, width, height);
+        }
+    }
+
+    fn get_error(&self) -> u32 {
+        unsafe { gl::GetError() }
+    }
+
+    fn read_buffer(&self, mode: u32) {
+        unsafe {
+            gl::ReadBuffer(mode);
+        }
+    }
+
+    fn draw_buffers(&self, buffers: &[u32]) {
+        unsafe { gl::DrawBuffers(buffers.len() as i32, buffers.as_ptr()) }
     }
 }

--- a/yage-gl/src/functions/gl_native.rs
+++ b/yage-gl/src/functions/gl_native.rs
@@ -715,17 +715,17 @@ impl super::GlFunctions for GL {
         }
     }
 
-    fn point_size(&self, size: f32) {
-        unsafe {
-            gl::PointSize(size);
-        }
-    }
-
     // Rasterization
 
     fn cull_face(&self, value: u32) {
         unsafe {
             gl::CullFace(value);
+        }
+    }
+
+    fn point_size(&self, size: f32) {
+        unsafe {
+            gl::PointSize(size);
         }
     }
 

--- a/yage-gl/src/functions/gl_web.rs
+++ b/yage-gl/src/functions/gl_web.rs
@@ -319,8 +319,8 @@ impl super::GlFunctions for GL {
             );
     }
 
-    fn generate_mipmap(&self) {
-        self.gl.generate_mipmap(glenum::TextureKind::Texture2d as _);
+    fn generate_mipmap(&self, target: u32) {
+        self.gl.generate_mipmap(target);
     }
 
     fn tex_parameteri(&self, target: u32, parameter: u32, value: i32) {
@@ -522,11 +522,19 @@ impl super::GlFunctions for GL {
     fn finish(&self) {
        self.gl.finish();
     }
+
     fn flush(&self) {
         self.gl.flush();
     }
 
-    fn create_transform_feedback(&self) -> Self::GlTransformFeedback {
-        self.gl.create_transform_feedback().unwrap()
+    fn get_parameter_i32(&self, parameter: u32) -> i32 {
+        self.gl.get_parameter(parameter)
+            .unwrap()
+            .as_f64()
+            .unwrap() as i32
     }
+
+    // fn create_transform_feedback(&self) -> Self::GlTransformFeedback {
+    //     self.gl.create_transform_feedback().unwrap()
+    // }
 }

--- a/yage-gl/src/functions/gl_web.rs
+++ b/yage-gl/src/functions/gl_web.rs
@@ -2,7 +2,7 @@ use glenum::*;
 
 use web_sys::{
     WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlProgram, WebGlRenderbuffer,
-    WebGlShader, WebGlTexture, WebGlUniformLocation, WebGlVertexArrayObject,
+    WebGlShader, WebGlTexture, WebGlUniformLocation, WebGlVertexArrayObject, WebGlTransformFeedback
 };
 
 pub struct GL {
@@ -25,6 +25,7 @@ impl super::GlFunctions for GL {
     type GlUniformLocation = WebGlUniformLocation;
     type GlFramebuffer = WebGlFramebuffer;
     type GlRenderbuffer = WebGlRenderbuffer;
+    type GlTransformFeedback = WebGlTransformFeedback;
 
     /// specify clear values for the color buffers
     fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {
@@ -34,6 +35,14 @@ impl super::GlFunctions for GL {
     /// clear buffers to preset values
     fn clear(&self, bit: BufferBit) {
         self.gl.clear(bit as _);
+    }
+
+    fn clear_depth(&self, depth: f32) {
+        self.gl.clear_depth(depth);
+    }
+
+    fn clear_stencil(&self, stencil: i32) {
+        self.gl.clear_stencil(stencil);
     }
 
     fn viewport(&self, x: i32, y: i32, width: i32, height: i32) {
@@ -148,6 +157,14 @@ impl super::GlFunctions for GL {
 
     fn delete_vertex_array(&self, vertex_array: &Self::GlVertexArray) {
         self.gl.delete_vertex_array(Some(vertex_array));
+    }
+
+    fn get_attrib_location(&self, program: &Self::GlProgram, name: &str) -> i32 {
+        self.gl.get_attrib_location(program, name)
+    }
+
+    fn bind_attrib_location(&self, program: &Self::GlProgram, index: u32, name: &str) {
+        self.gl.bind_attrib_location(program, index, name);
     }
 
     fn vertex_attrib_pointer(
@@ -271,6 +288,37 @@ impl super::GlFunctions for GL {
             );
     }
 
+    fn tex_image_3d(
+        &self,
+        target: u32,
+        level: i32,
+        internal_format: i32,
+        width: i32,
+        height: i32,
+        depth: i32,
+        border: i32,
+        format: u32,
+        ty: u32,
+        pixels: Option<&[u8]>,
+    ) {
+        // TODO!: unused_must_use - return Result?
+        let _ = self
+            .gl
+            .tex_image_3d_with_u8_array_and_src_offset(
+                target,
+                level,
+                internal_format,
+                width,
+                height,
+                depth,
+                border,
+                format,
+                ty,
+                pixels.unwrap(), // TODO!: none case?
+                0
+            );
+    }
+
     fn generate_mipmap(&self) {
         self.gl.generate_mipmap(glenum::TextureKind::Texture2d as _);
     }
@@ -373,6 +421,24 @@ impl super::GlFunctions for GL {
         self.gl.check_framebuffer_status(target)
     }
 
+    fn blit_framebuffer(
+        &self,
+        src_x0: i32,
+        src_y0: i32,
+        src_x1: i32,
+        src_y1: i32,
+        dst_x0: i32,
+        dst_y0: i32,
+        dst_x1: i32,
+        dst_y1: i32,
+        mask: u32,
+        filter: u32,
+    ) {
+        self.gl.blit_framebuffer(
+            src_x0, src_y0, src_x1, src_y1, dst_x0, dst_y0, dst_x1, dst_y1, mask, filter
+        );
+    }
+
     /// Unimplemented - method missing in WebGL (and ES2, ES3)
     fn polygon_mode(&self, _face: u32, _mode: u32) {
         // TODO!: log warning instead of panic?
@@ -435,9 +501,32 @@ impl super::GlFunctions for GL {
     }
 
     /// unimplemented (yet)
-    fn draw_buffers(&self, buffers: &[u32]) {
+    fn draw_buffers(&self, _buffers: &[u32]) {
         // TODO!!: requires JsValue...?
         // self.gl.draw_buffers(buffers);
         unimplemented!()
+    }
+
+    fn is_buffer(&self, buffer: &Self::GlBuffer) -> bool {
+        self.gl.is_buffer(Some(buffer))
+    }
+
+    fn is_frambuffer(&self, framebuffer: &Self::GlFramebuffer) -> bool {
+        self.gl.is_framebuffer(Some(framebuffer))
+    }
+
+    fn is_texture(&self, texture: &Self::GlTexture) -> bool {
+        self.gl.is_texture(Some(texture))
+    }
+
+    fn finish(&self) {
+       self.gl.finish();
+    }
+    fn flush(&self) {
+        self.gl.flush();
+    }
+
+    fn create_transform_feedback(&self) -> Self::GlTransformFeedback {
+        self.gl.create_transform_feedback().unwrap()
     }
 }

--- a/yage-gl/src/functions/gl_web.rs
+++ b/yage-gl/src/functions/gl_web.rs
@@ -27,27 +27,17 @@ impl super::GlFunctions for GL {
     type GlRenderbuffer = WebGlRenderbuffer;
     type GlTransformFeedback = WebGlTransformFeedback;
 
-    /// specify clear values for the color buffers
-    fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {
-        self.gl.clear_color(r, g, b, a);
-    }
-
-    /// clear buffers to preset values
-    fn clear(&self, bit: BufferBit) {
-        self.gl.clear(bit as _);
-    }
-
-    fn clear_depth(&self, depth: f32) {
-        self.gl.clear_depth(depth);
-    }
-
-    fn clear_stencil(&self, stencil: i32) {
-        self.gl.clear_stencil(stencil);
-    }
+    // View and Clip
 
     fn viewport(&self, x: i32, y: i32, width: i32, height: i32) {
         self.gl.viewport(x, y, width, height);
     }
+
+    fn scissor(&self, x: i32, y: i32, width: i32, height: i32) {
+        self.gl.scissor(x, y, width, height);
+    }
+
+    // Programs and Shaders
 
     fn create_shader(&self, kind: glenum::ShaderKind) -> Self::GlShader {
         self.gl.create_shader(kind as _).unwrap()
@@ -109,6 +99,16 @@ impl super::GlFunctions for GL {
         self.gl.use_program(program);
     }
 
+    fn get_attrib_location(&self, program: &Self::GlProgram, name: &str) -> i32 {
+        self.gl.get_attrib_location(program, name)
+    }
+
+    fn bind_attrib_location(&self, program: &Self::GlProgram, index: u32, name: &str) {
+        self.gl.bind_attrib_location(program, index, name);
+    }
+
+    // Buffer Objects
+
     fn create_buffer(&self) -> Self::GlBuffer {
         self.gl.create_buffer().unwrap()
     }
@@ -147,6 +147,12 @@ impl super::GlFunctions for GL {
         self.gl.delete_buffer(Some(&buffer));
     }
 
+    fn is_buffer(&self, buffer: &Self::GlBuffer) -> bool {
+        self.gl.is_buffer(Some(buffer))
+    }
+
+    // Vertex Array Objects
+
     fn create_vertex_array(&self) -> Self::GlVertexArray {
         self.gl.create_vertex_array().unwrap()
     }
@@ -159,13 +165,7 @@ impl super::GlFunctions for GL {
         self.gl.delete_vertex_array(Some(vertex_array));
     }
 
-    fn get_attrib_location(&self, program: &Self::GlProgram, name: &str) -> i32 {
-        self.gl.get_attrib_location(program, name)
-    }
-
-    fn bind_attrib_location(&self, program: &Self::GlProgram, index: u32, name: &str) {
-        self.gl.bind_attrib_location(program, index, name);
-    }
+    // Uniforms and Attributes
 
     fn vertex_attrib_pointer(
         &self,
@@ -180,10 +180,6 @@ impl super::GlFunctions for GL {
             .vertex_attrib_pointer_with_i32(index, size, data_type, normalized, stride, offset);
     }
 
-    fn vertex_attrib_divisor(&self, index: u32, divisor: u32) {
-        self.gl.vertex_attrib_divisor(index, divisor);
-    }
-
     fn enable_vertex_attrib_array(&self, index: u32) {
         self.gl.enable_vertex_attrib_array(index);
     }
@@ -192,17 +188,61 @@ impl super::GlFunctions for GL {
         self.gl.disable_vertex_attrib_array(index);
     }
 
-    fn draw_arrays(&self, mode: u32, first: i32, count: i32) {
-        self.gl.draw_arrays(mode, first, count);
+    fn get_uniform_location(
+        &self,
+        program: &Self::GlProgram,
+        name: &str,
+    ) -> Self::GlUniformLocation {
+        self.gl.get_uniform_location(program, name).unwrap()
     }
 
-    fn draw_arrays_instanced(&self, mode: u32, first: i32, count: i32, instance_count: i32) {
-        self.gl.draw_arrays_instanced(mode, first, count, instance_count);
+    fn uniform_1i(&self, location: &Self::GlUniformLocation, x: i32) {
+        self.gl.uniform1i(Some(location), x);
+    }
+
+    fn uniform_1f(&self, location: &Self::GlUniformLocation, x: f32) {
+        self.gl.uniform1f(Some(location), x);
+    }
+
+    fn uniform_3fv(&self, location: &Self::GlUniformLocation, x: &[f32; 3]) {
+        self.gl.uniform3fv_with_f32_array(Some(location), x);
+    }
+
+    fn uniform_4fv(&self, location: &Self::GlUniformLocation, x: &[f32; 4]) {
+        self.gl.uniform4fv_with_f32_array(Some(location), x);
+    }
+
+    fn uniform_2f(&self, location: &Self::GlUniformLocation, x: f32, y: f32) {
+        self.gl.uniform2f(Some(location), x, y);
+    }
+
+    fn uniform_3f(&self, location: &Self::GlUniformLocation, x: f32, y: f32, z: f32) {
+        self.gl.uniform3f(Some(location), x, y, z);
+    }
+
+    fn uniform_matrix_4fv(&self, _location: &Self::GlUniformLocation, _mat: &[[f32; 4]; 4]) {
+        // TODO!!: how to convert properly?
+        // self.gl.uniform_matrix4fv_with_f32_array(Some(location), false, std::mem::transmute(mat));
+        unimplemented!();
+    }
+
+    // Writing to the Draw Buffer
+
+    fn draw_arrays(&self, mode: u32, first: i32, count: i32) {
+        self.gl.draw_arrays(mode, first, count);
     }
 
     fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32) {
         self.gl
             .draw_elements_with_i32(mode, count, element_type, offset);
+    }
+
+    fn vertex_attrib_divisor(&self, index: u32, divisor: u32) {
+        self.gl.vertex_attrib_divisor(index, divisor);
+    }
+
+    fn draw_arrays_instanced(&self, mode: u32, first: i32, count: i32, instance_count: i32) {
+        self.gl.draw_arrays_instanced(mode, first, count, instance_count);
     }
 
     fn draw_elements_instanced(
@@ -222,6 +262,8 @@ impl super::GlFunctions for GL {
         );
     }
 
+    // Special Functions
+
     fn enable(&self, param: u32) {
         self.gl.enable(param);
     }
@@ -230,11 +272,36 @@ impl super::GlFunctions for GL {
         self.gl.disable(param);
     }
 
+    fn finish(&self) {
+       self.gl.finish();
+    }
+
+    fn flush(&self) {
+        self.gl.flush();
+    }
+
+    fn get_error(&self) -> u32 {
+        self.gl.get_error()
+    }
+
+    fn get_parameter_i32(&self, parameter: u32) -> i32 {
+        self.gl.get_parameter(parameter)
+            .unwrap()
+            .as_f64()
+            .unwrap() as i32
+    }
+
+    fn pixel_storei(&self, storage: u32, value: i32) {
+        self.gl.pixel_storei(storage, value);
+    }
+
     /// Unimplemented - method missing in WebGL (and ES2, ES3)
     fn point_size(&self, _size: f32) {
         // TODO!: log warning instead of panic?
         unimplemented!("method not available in WebGL")
     }
+
+    // Texture Objects
 
     fn active_texture(&self, unit: u32) {
         self.gl.active_texture(unit);
@@ -242,14 +309,6 @@ impl super::GlFunctions for GL {
 
     fn bind_texture(&self, target: u32, texture: Option<&Self::GlTexture>) {
         self.gl.bind_texture(target, texture);
-    }
-
-    fn blend_func(&self, src: u32, dst: u32) {
-        self.gl.blend_func(src, dst);
-    }
-
-    fn blend_func_separate(&self, src_rgb: u32, dst_rgb: u32, src_alpha: u32, dst_alpha: u32) {
-        self.gl.blend_func_separate(src_rgb, dst_rgb, src_alpha, dst_alpha);
     }
 
     fn create_texture(&self) -> Self::GlTexture {
@@ -327,42 +386,8 @@ impl super::GlFunctions for GL {
         self.gl.tex_parameteri(target, parameter, value);
     }
 
-    fn get_uniform_location(
-        &self,
-        program: &Self::GlProgram,
-        name: &str,
-    ) -> Self::GlUniformLocation {
-        self.gl.get_uniform_location(program, name).unwrap()
-    }
-
-    fn uniform_1i(&self, location: &Self::GlUniformLocation, x: i32) {
-        self.gl.uniform1i(Some(location), x);
-    }
-
-    fn uniform_1f(&self, location: &Self::GlUniformLocation, x: f32) {
-        self.gl.uniform1f(Some(location), x);
-    }
-
-    fn uniform_3fv(&self, location: &Self::GlUniformLocation, x: &[f32; 3]) {
-        self.gl.uniform3fv_with_f32_array(Some(location), x);
-    }
-
-    fn uniform_4fv(&self, location: &Self::GlUniformLocation, x: &[f32; 4]) {
-        self.gl.uniform4fv_with_f32_array(Some(location), x);
-    }
-
-    fn uniform_2f(&self, location: &Self::GlUniformLocation, x: f32, y: f32) {
-        self.gl.uniform2f(Some(location), x, y);
-    }
-
-    fn uniform_3f(&self, location: &Self::GlUniformLocation, x: f32, y: f32, z: f32) {
-        self.gl.uniform3f(Some(location), x, y, z);
-    }
-
-    fn uniform_matrix_4fv(&self, _location: &Self::GlUniformLocation, _mat: &[[f32; 4]; 4]) {
-        // TODO!!: how to convert properly?
-        // self.gl.uniform_matrix4fv_with_f32_array(Some(location), false, std::mem::transmute(mat));
-        unimplemented!();
+    fn is_texture(&self, texture: &Self::GlTexture) -> bool {
+        self.gl.is_texture(Some(texture))
     }
 
     fn create_framebuffer(&self) -> Self::GlFramebuffer {
@@ -389,23 +414,6 @@ impl super::GlFunctions for GL {
             .framebuffer_texture_2d(target, attachment, texture_target, texture, level);
     }
 
-    fn create_renderbuffer(&self) -> Self::GlRenderbuffer {
-        self.gl.create_renderbuffer().unwrap()
-    }
-
-    fn delete_renderbuffer(&self, renderbuffer: &Self::GlRenderbuffer) {
-        self.gl.delete_renderbuffer(Some(renderbuffer));
-    }
-
-    fn bind_renderbuffer(&self, target: u32, renderbuffer: Option<&Self::GlRenderbuffer>) {
-        self.gl.bind_renderbuffer(target, renderbuffer);
-    }
-
-    fn renderbuffer_storage(&self, target: u32, internal_format: u32, width: i32, height: i32) {
-        self.gl
-            .renderbuffer_storage(target, internal_format, width, height);
-    }
-
     fn framebuffer_renderbuffer(
         &self,
         target: u32,
@@ -415,6 +423,10 @@ impl super::GlFunctions for GL {
     ) {
         self.gl
             .framebuffer_renderbuffer(target, attachment, renderbuffer_target, renderbuffer);
+    }
+
+    fn is_frambuffer(&self, framebuffer: &Self::GlFramebuffer) -> bool {
+        self.gl.is_framebuffer(Some(framebuffer))
     }
 
     fn check_framebuffer_status(&self, target: u32) -> u32 {
@@ -439,15 +451,78 @@ impl super::GlFunctions for GL {
         );
     }
 
-    /// Unimplemented - method missing in WebGL (and ES2, ES3)
-    fn polygon_mode(&self, _face: u32, _mode: u32) {
-        // TODO!: log warning instead of panic?
-        unimplemented!("method not available in WebGL")
+    fn read_buffer(&self, mode: u32) {
+        self.gl.read_buffer(mode);
     }
 
-    fn pixel_storei(&self, storage: u32, value: i32) {
-        self.gl.pixel_storei(storage, value);
+    // Renderbuffer Objects
+
+    fn create_renderbuffer(&self) -> Self::GlRenderbuffer {
+        self.gl.create_renderbuffer().unwrap()
     }
+
+    fn delete_renderbuffer(&self, renderbuffer: &Self::GlRenderbuffer) {
+        self.gl.delete_renderbuffer(Some(renderbuffer));
+    }
+
+    fn bind_renderbuffer(&self, target: u32, renderbuffer: Option<&Self::GlRenderbuffer>) {
+        self.gl.bind_renderbuffer(target, renderbuffer);
+    }
+
+    fn renderbuffer_storage(&self, target: u32, internal_format: u32, width: i32, height: i32) {
+        self.gl
+            .renderbuffer_storage(target, internal_format, width, height);
+    }
+
+    // Per-Fragment Operations
+
+    fn depth_func(&self, func: u32) {
+        self.gl.depth_func(func);
+    }
+
+    fn blend_func(&self, src: u32, dst: u32) {
+        self.gl.blend_func(src, dst);
+    }
+
+    fn blend_func_separate(&self, src_rgb: u32, dst_rgb: u32, src_alpha: u32, dst_alpha: u32) {
+        self.gl.blend_func_separate(src_rgb, dst_rgb, src_alpha, dst_alpha);
+    }
+
+    fn stencil_func(&self, func: u32, reference: i32, mask: u32){
+        self.gl.stencil_func(func, reference, mask);
+    }
+
+    fn stencil_op(&self, stencil_fail: u32, depth_fail: u32, pass: u32){
+        self.gl.stencil_op(stencil_fail, depth_fail, pass);
+    }
+
+    // Whole Framebuffer Operations
+
+    fn clear(&self, bit: BufferBit) {
+        self.gl.clear(bit as _);
+    }
+
+    fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {
+        self.gl.clear_color(r, g, b, a);
+    }
+
+    fn clear_depth(&self, depth: f32) {
+        self.gl.clear_depth(depth);
+    }
+
+    fn clear_stencil(&self, stencil: i32) {
+        self.gl.clear_stencil(stencil);
+    }
+
+    fn stencil_mask(&self, mask: u32){
+        self.gl.stencil_mask(mask);
+    }
+
+    fn depth_mask(&self, value: bool) {
+        self.gl.depth_mask(value);
+    }
+
+    // Read Back Pixels
 
     fn read_pixels(
         &self,
@@ -464,41 +539,19 @@ impl super::GlFunctions for GL {
             format, type_, Some(data));
     }
 
-    fn depth_func(&self, func: u32) {
-        self.gl.depth_func(func);
-    }
-
-    fn depth_mask(&self, value: bool) {
-        self.gl.depth_mask(value);
-    }
-
-    fn stencil_func(&self, func: u32, reference: i32, mask: u32){
-        self.gl.stencil_func(func, reference, mask);
-    }
-
-    fn stencil_mask(&self, mask: u32){
-        self.gl.stencil_mask(mask);
-    }
-
-    fn stencil_op(&self, stencil_fail: u32, depth_fail: u32, pass: u32){
-        self.gl.stencil_op(stencil_fail, depth_fail, pass);
-    }
+    // Rasterization
 
     fn cull_face(&self, value: u32) {
         self.gl.cull_face(value);
     }
 
-    fn scissor(&self, x: i32, y: i32, width: i32, height: i32) {
-        self.gl.scissor(x, y, width, height);
+    /// Unimplemented - method missing in WebGL (and ES2, ES3)
+    fn polygon_mode(&self, _face: u32, _mode: u32) {
+        // TODO!: log warning instead of panic?
+        unimplemented!("method not available in WebGL")
     }
 
-    fn get_error(&self) -> u32 {
-        self.gl.get_error()
-    }
-
-    fn read_buffer(&self, mode: u32) {
-        self.gl.read_buffer(mode);
-    }
+    // Multiple Render Targets
 
     /// unimplemented (yet)
     fn draw_buffers(&self, _buffers: &[u32]) {
@@ -507,32 +560,7 @@ impl super::GlFunctions for GL {
         unimplemented!()
     }
 
-    fn is_buffer(&self, buffer: &Self::GlBuffer) -> bool {
-        self.gl.is_buffer(Some(buffer))
-    }
-
-    fn is_frambuffer(&self, framebuffer: &Self::GlFramebuffer) -> bool {
-        self.gl.is_framebuffer(Some(framebuffer))
-    }
-
-    fn is_texture(&self, texture: &Self::GlTexture) -> bool {
-        self.gl.is_texture(Some(texture))
-    }
-
-    fn finish(&self) {
-       self.gl.finish();
-    }
-
-    fn flush(&self) {
-        self.gl.flush();
-    }
-
-    fn get_parameter_i32(&self, parameter: u32) -> i32 {
-        self.gl.get_parameter(parameter)
-            .unwrap()
-            .as_f64()
-            .unwrap() as i32
-    }
+    // Transform Feedback
 
     // fn create_transform_feedback(&self) -> Self::GlTransformFeedback {
     //     self.gl.create_transform_feedback().unwrap()

--- a/yage-gl/src/functions/gl_web.rs
+++ b/yage-gl/src/functions/gl_web.rs
@@ -1,5 +1,3 @@
-use glenum::*;
-
 use web_sys::{
     WebGl2RenderingContext, WebGlBuffer, WebGlFramebuffer, WebGlProgram, WebGlRenderbuffer,
     WebGlShader, WebGlTexture, WebGlUniformLocation, WebGlVertexArrayObject, WebGlTransformFeedback
@@ -498,8 +496,8 @@ impl super::GlFunctions for GL {
 
     // Whole Framebuffer Operations
 
-    fn clear(&self, bit: BufferBit) {
-        self.gl.clear(bit as _);
+    fn clear(&self, mask: u32) {
+        self.gl.clear(mask);
     }
 
     fn clear_color(&self, r: f32, g: f32, b: f32, a: f32) {

--- a/yage-gl/src/functions/gl_web.rs
+++ b/yage-gl/src/functions/gl_web.rs
@@ -76,6 +76,10 @@ impl super::GlFunctions for GL {
         self.gl.attach_shader(&program, shader);
     }
 
+    fn detach_shader(&self, program: &Self::GlProgram, shader: &Self::GlShader) {
+        self.gl.detach_shader(&program, shader);
+    }
+
     fn link_program(&self, program: &Self::GlProgram) {
         self.gl.link_program(&program);
     }
@@ -159,6 +163,10 @@ impl super::GlFunctions for GL {
             .vertex_attrib_pointer_with_i32(index, size, data_type, normalized, stride, offset);
     }
 
+    fn vertex_attrib_divisor(&self, index: u32, divisor: u32) {
+        self.gl.vertex_attrib_divisor(index, divisor);
+    }
+
     fn enable_vertex_attrib_array(&self, index: u32) {
         self.gl.enable_vertex_attrib_array(index);
     }
@@ -171,9 +179,30 @@ impl super::GlFunctions for GL {
         self.gl.draw_arrays(mode, first, count);
     }
 
+    fn draw_arrays_instanced(&self, mode: u32, first: i32, count: i32, instance_count: i32) {
+        self.gl.draw_arrays_instanced(mode, first, count, instance_count);
+    }
+
     fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32) {
         self.gl
             .draw_elements_with_i32(mode, count, element_type, offset);
+    }
+
+    fn draw_elements_instanced(
+        &self,
+        mode: u32,
+        count: i32,
+        element_type: u32,
+        offset: i32,
+        instance_count: i32,
+    ) {
+        self.gl.draw_elements_instanced_with_i32(
+            mode as u32,
+            count,
+            element_type as u32,
+            offset,
+            instance_count,
+        );
     }
 
     fn enable(&self, param: u32) {
@@ -200,6 +229,10 @@ impl super::GlFunctions for GL {
 
     fn blend_func(&self, src: u32, dst: u32) {
         self.gl.blend_func(src, dst);
+    }
+
+    fn blend_func_separate(&self, src_rgb: u32, dst_rgb: u32, src_alpha: u32, dst_alpha: u32) {
+        self.gl.blend_func_separate(src_rgb, dst_rgb, src_alpha, dst_alpha);
     }
 
     fn create_texture(&self) -> Self::GlTexture {
@@ -363,5 +396,48 @@ impl super::GlFunctions for GL {
         // TODO: unused_must_use - return Result?
         let _ = self.gl.read_pixels_with_opt_u8_array(x, y, width, height,
             format, type_, Some(data));
+    }
+
+    fn depth_func(&self, func: u32) {
+        self.gl.depth_func(func);
+    }
+
+    fn depth_mask(&self, value: bool) {
+        self.gl.depth_mask(value);
+    }
+
+    fn stencil_func(&self, func: u32, reference: i32, mask: u32){
+        self.gl.stencil_func(func, reference, mask);
+    }
+
+    fn stencil_mask(&self, mask: u32){
+        self.gl.stencil_mask(mask);
+    }
+
+    fn stencil_op(&self, stencil_fail: u32, depth_fail: u32, pass: u32){
+        self.gl.stencil_op(stencil_fail, depth_fail, pass);
+    }
+
+    fn cull_face(&self, value: u32) {
+        self.gl.cull_face(value);
+    }
+
+    fn scissor(&self, x: i32, y: i32, width: i32, height: i32) {
+        self.gl.scissor(x, y, width, height);
+    }
+
+    fn get_error(&self) -> u32 {
+        self.gl.get_error()
+    }
+
+    fn read_buffer(&self, mode: u32) {
+        self.gl.read_buffer(mode);
+    }
+
+    /// unimplemented (yet)
+    fn draw_buffers(&self, buffers: &[u32]) {
+        // TODO!!: requires JsValue...?
+        // self.gl.draw_buffers(buffers);
+        unimplemented!()
     }
 }

--- a/yage-gl/src/functions/glfunctions.rs
+++ b/yage-gl/src/functions/glfunctions.rs
@@ -20,13 +20,12 @@ pub trait GlFunctions {
     type GlRenderbuffer;
     type GlTransformFeedback;
 
-    fn clear_color(&self, r: f32, g: f32, b: f32, a: f32);
-    fn clear(&self, bit: BufferBit);
-    fn clear_depth(&self, depth: f32);
-    fn clear_stencil(&self, stencil: i32);
-    // TODO: glClearBuffer - 4 variants...
+    // View and Clip
 
+    fn scissor(&self, x: i32, y: i32, width: i32, height: i32);
     fn viewport(&self, x: i32, y: i32, width: i32, height: i32);
+
+    // Programs and Shaders
 
     fn create_shader(&self, kind: glenum::ShaderKind) -> Self::GlShader;
     fn shader_source(&self, shader: &Self::GlShader, source: &str);
@@ -43,6 +42,10 @@ pub trait GlFunctions {
     fn get_program_parameter(&self, program: &Self::GlProgram, param: u32) -> i32;
     fn get_program_info_log(&self, program: &Self::GlProgram) -> String;
     fn use_program(&self, program: Option<&Self::GlProgram>);
+    fn get_attrib_location(&self, program: &Self::GlProgram, name: &str) -> i32;
+    fn bind_attrib_location(&self, program: &Self::GlProgram, index: u32, name: &str);
+
+    // Buffer Objects
 
     /// Named after the WebGL function. See `gl::GenBuffers` for OpenGL.
     fn create_buffer(&self) -> Self::GlBuffer;
@@ -50,13 +53,16 @@ pub trait GlFunctions {
     fn buffer_data<T>(&self, target: u32, data: &[T], usage: u32);
     fn buffer_sub_data<T>(&self, target: u32, offset: isize, data: &[T]);
     fn delete_buffer(&self, buffer: &Self::GlBuffer);
+    fn is_buffer(&self, buffer: &Self::GlBuffer) -> bool;
+
+    // Vertex Array Objects
 
     fn create_vertex_array(&self) -> Self::GlVertexArray;
     fn bind_vertex_array(&self, vertex_array: Option<&Self::GlVertexArray>);
     fn delete_vertex_array(&self, vertex_array: &Self::GlVertexArray);
 
-    fn get_attrib_location(&self, program: &Self::GlProgram, name: &str) -> i32;
-    fn bind_attrib_location(&self, program: &Self::GlProgram, index: u32, name: &str);
+    // Uniforms and Attributes
+
     fn vertex_attrib_pointer(
         &self,
         index: u32,
@@ -66,13 +72,29 @@ pub trait GlFunctions {
         stride: i32,
         offset: i32,
     );
-    fn vertex_attrib_divisor(&self, index: u32, divisor: u32);
     fn enable_vertex_attrib_array(&self, index: u32);
     fn disable_vertex_attrib_array(&self, index: u32);
 
+    fn get_uniform_location(
+        &self,
+        program: &Self::GlProgram,
+        name: &str,
+    ) -> Self::GlUniformLocation;
+    fn uniform_1i(&self, location: &Self::GlUniformLocation, x: i32);
+    fn uniform_1f(&self, location: &Self::GlUniformLocation, x: f32);
+    fn uniform_3fv(&self, location: &Self::GlUniformLocation, x: &[f32; 3]);
+    fn uniform_4fv(&self, location: &Self::GlUniformLocation, x: &[f32; 4]);
+    fn uniform_2f(&self, location: &Self::GlUniformLocation, x: f32, y: f32);
+    fn uniform_3f(&self, location: &Self::GlUniformLocation, x: f32, y: f32, z: f32);
+    fn uniform_matrix_4fv(&self, location: &Self::GlUniformLocation, value: &[[f32; 4]; 4]);
+
+    // Writing to the Draw Buffer
+
     fn draw_arrays(&self, mode: u32, first: i32, count: i32);
-    fn draw_arrays_instanced(&self, mode: u32, first: i32, count: i32, instance_count: i32);
     fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32);
+
+    fn vertex_attrib_divisor(&self, index: u32, divisor: u32);
+    fn draw_arrays_instanced(&self, mode: u32, first: i32, count: i32, instance_count: i32);
     fn draw_elements_instanced(
         &self,
         mode: u32,
@@ -82,16 +104,20 @@ pub trait GlFunctions {
         instance_count: i32,
     );
 
+    // Special Functions
+
     fn enable(&self, param: u32);
     fn disable(&self, param: u32);
+    fn finish(&self);
+    fn flush(&self);
+    fn get_error(&self) -> u32;
+    fn get_parameter_i32(&self, parameter: u32) -> i32;
+    fn pixel_storei(&self, storage: u32, value: i32);
 
-    fn point_size(&self, size: f32);
+    // Texture Objects
 
     fn active_texture(&self, unit: u32);
     fn bind_texture(&self, target: u32, texture: Option<&Self::GlTexture>);
-
-    fn blend_func(&self, src: u32, dst: u32);
-    fn blend_func_separate(&self, src_rgb: u32, dst_rgb: u32, src_alpha: u32, dst_alpha: u32);
 
     fn create_texture(&self) -> Self::GlTexture;
     fn delete_texture(&self, texture: &Self::GlTexture);
@@ -129,19 +155,9 @@ pub trait GlFunctions {
 
     fn tex_parameteri(&self, target: u32, parameter: u32, value: i32);
 
-    fn get_uniform_location(
-        &self,
-        program: &Self::GlProgram,
-        name: &str,
-    ) -> Self::GlUniformLocation;
+    fn is_texture(&self, texture: &Self::GlTexture) -> bool;
 
-    fn uniform_1i(&self, location: &Self::GlUniformLocation, x: i32);
-    fn uniform_1f(&self, location: &Self::GlUniformLocation, x: f32);
-    fn uniform_3fv(&self, location: &Self::GlUniformLocation, x: &[f32; 3]);
-    fn uniform_4fv(&self, location: &Self::GlUniformLocation, x: &[f32; 4]);
-    fn uniform_2f(&self, location: &Self::GlUniformLocation, x: f32, y: f32);
-    fn uniform_3f(&self, location: &Self::GlUniformLocation, x: f32, y: f32, z: f32);
-    fn uniform_matrix_4fv(&self, location: &Self::GlUniformLocation, value: &[[f32; 4]; 4]);
+    // Framebuffer Objects
 
     fn create_framebuffer(&self) -> Self::GlFramebuffer;
     fn delete_framebuffer(&self, framebuffer: &Self::GlFramebuffer);
@@ -154,11 +170,6 @@ pub trait GlFunctions {
         texture: Option<&Self::GlTexture>,
         level: i32,
     );
-
-    fn create_renderbuffer(&self) -> Self::GlRenderbuffer;
-    fn delete_renderbuffer(&self, renderbuffer: &Self::GlRenderbuffer);
-    fn bind_renderbuffer(&self, target: u32, renderbuffer: Option<&Self::GlRenderbuffer>);
-    fn renderbuffer_storage(&self, target: u32, internal_format: u32, width: i32, height: i32);
     fn framebuffer_renderbuffer(
         &self,
         target: u32,
@@ -166,6 +177,7 @@ pub trait GlFunctions {
         renderbuffer_target: u32,
         renderbuffer: Option<&Self::GlRenderbuffer>,
     );
+    fn is_frambuffer(&self, framebuffer: &Self::GlFramebuffer) -> bool;
     fn check_framebuffer_status(&self, target: u32) -> u32;
     #[allow(clippy::too_many_arguments)]
     fn blit_framebuffer(
@@ -181,10 +193,34 @@ pub trait GlFunctions {
         mask: u32,
         filter: u32,
     );
+    fn read_buffer(&self, mode: u32);
 
-    fn polygon_mode(&self, face: u32, mode: u32);
+    // Renderbuffer Objects
 
-    fn pixel_storei(&self, storage: u32, value: i32);
+    fn create_renderbuffer(&self) -> Self::GlRenderbuffer;
+    fn delete_renderbuffer(&self, renderbuffer: &Self::GlRenderbuffer);
+    fn bind_renderbuffer(&self, target: u32, renderbuffer: Option<&Self::GlRenderbuffer>);
+    fn renderbuffer_storage(&self, target: u32, internal_format: u32, width: i32, height: i32);
+
+    // Per-Fragment Operations
+
+    fn blend_func(&self, src: u32, dst: u32);
+    fn blend_func_separate(&self, src_rgb: u32, dst_rgb: u32, src_alpha: u32, dst_alpha: u32);
+    fn depth_func(&self, func: u32);
+    fn stencil_func(&self, func: u32, reference: i32, mask: u32);
+    fn stencil_op(&self, stencil_fail: u32, depth_fail: u32, pass: u32);
+
+    // Whole Framebuffer Operations
+
+    fn clear(&self, bit: BufferBit);
+    fn clear_color(&self, r: f32, g: f32, b: f32, a: f32);
+    fn clear_depth(&self, depth: f32);
+    fn clear_stencil(&self, stencil: i32);
+
+    fn depth_mask(&self, value: bool);
+    fn stencil_mask(&self, mask: u32);
+
+    // Read Back Pixels
 
     #[allow(clippy::too_many_arguments)]
     fn read_pixels(
@@ -198,29 +234,18 @@ pub trait GlFunctions {
         data: &mut [u8],
     );
 
-    fn depth_func(&self, func: u32);
-    fn depth_mask(&self, value: bool);
-
-    fn stencil_func(&self, func: u32, reference: i32, mask: u32);
-    fn stencil_mask(&self, mask: u32);
-    fn stencil_op(&self, stencil_fail: u32, depth_fail: u32, pass: u32);
+    // Rasterization
 
     fn cull_face(&self, value: u32);
-    fn scissor(&self, x: i32, y: i32, width: i32, height: i32);
+    fn point_size(&self, size: f32);
+    fn polygon_mode(&self, face: u32, mode: u32);
 
-    fn get_error(&self) -> u32;
+    // Multiple Render Targets
 
-    fn read_buffer(&self, mode: u32);
     fn draw_buffers(&self, buffers: &[u32]);
+    // TODO: glClearBuffer - 4 variants...
 
-    fn is_buffer(&self, buffer: &Self::GlBuffer) -> bool;
-    fn is_frambuffer(&self, framebuffer: &Self::GlFramebuffer) -> bool;
-    fn is_texture(&self, texture: &Self::GlTexture) -> bool;
-
-    fn finish(&self);
-    fn flush(&self);
-
-    fn get_parameter_i32(&self, parameter: u32) -> i32;
+    // Transform Feedback
 
     // TODO!: transform feeback (NOTE: create is implemented, but commented out)
     // fn create_transform_feedback(&self) -> Self::GlTransformFeedback;

--- a/yage-gl/src/functions/glfunctions.rs
+++ b/yage-gl/src/functions/glfunctions.rs
@@ -34,6 +34,7 @@ pub trait GlFunctions {
 
     fn create_program(&self) -> Self::GlProgram;
     fn attach_shader(&self, program: &Self::GlProgram, shader: &Self::GlShader);
+    fn detach_shader(&self, program: &Self::GlProgram, shader: &Self::GlShader);
     fn link_program(&self, program: &Self::GlProgram);
     fn get_program_parameter(&self, program: &Self::GlProgram, param: u32) -> i32;
     fn get_program_info_log(&self, program: &Self::GlProgram) -> String;
@@ -58,11 +59,21 @@ pub trait GlFunctions {
         stride: i32,
         offset: i32,
     );
+    fn vertex_attrib_divisor(&self, index: u32, divisor: u32);
     fn enable_vertex_attrib_array(&self, index: u32);
     fn disable_vertex_attrib_array(&self, index: u32);
 
     fn draw_arrays(&self, mode: u32, first: i32, count: i32);
+    fn draw_arrays_instanced(&self, mode: u32, first: i32, count: i32, instance_count: i32);
     fn draw_elements(&self, mode: u32, count: i32, element_type: u32, offset: i32);
+    fn draw_elements_instanced(
+        &self,
+        mode: u32,
+        count: i32,
+        element_type: u32,
+        offset: i32,
+        instance_count: i32,
+    );
 
     fn enable(&self, param: u32);
     fn disable(&self, param: u32);
@@ -73,6 +84,7 @@ pub trait GlFunctions {
     fn bind_texture(&self, target: u32, texture: Option<&Self::GlTexture>);
 
     fn blend_func(&self, src: u32, dst: u32);
+    fn blend_func_separate(&self, src_rgb: u32, dst_rgb: u32, src_alpha: u32, dst_alpha: u32);
 
     fn create_texture(&self) -> Self::GlTexture;
     fn delete_texture(&self, texture: &Self::GlTexture);
@@ -150,12 +162,32 @@ pub trait GlFunctions {
         data: &mut [u8],
     );
 
-    // TODO!: drawArraysInstanced, vertex_attrib_divisor,
-    // image3D, cubemap, stencil_func etc., blendFuncSeparate
-    // depthMask, depth_func
+    fn depth_func(&self, func: u32);
+    fn depth_mask(&self, value: bool);
+
+    fn stencil_func(&self, func: u32, reference: i32, mask: u32);
+    fn stencil_mask(&self, mask: u32);
+    fn stencil_op(&self, stencil_fail: u32, depth_fail: u32, pass: u32);
+
+    fn cull_face(&self, value: u32);
+    fn scissor(&self, x: i32, y: i32, width: i32, height: i32);
+
+    fn get_error(&self) -> u32;
+
+    fn read_buffer(&self, mode: u32);
+    fn draw_buffers(&self, buffers: &[u32]);
+
+    // TODO!:
+    // texImage3D, cubemap,
     // glClearBuffer, glClearStencil, glClearDepth
     // glDrawBuffers
     // glIsFramebuffer
+    // glBlitFramebuffer
+    // glIsBuffer
+    // get_parameter / GetIntegerv
+    // bindAttribLocation, getAttribLocation
+    // isTexture
+    // glFinish
     //
     // tf: createTransformFeedback,
     // bindTransformFeedback, bindBufferBase

--- a/yage-gl/src/functions/glfunctions.rs
+++ b/yage-gl/src/functions/glfunctions.rs
@@ -1,5 +1,3 @@
-use glenum::BufferBit;
-
 /// Trait for many GL functions
 ///
 /// Associated types are used to support different handles types in native GL and WebGL
@@ -212,7 +210,7 @@ pub trait GlFunctions {
 
     // Whole Framebuffer Operations
 
-    fn clear(&self, bit: BufferBit);
+    fn clear(&self, mask: u32);
     fn clear_color(&self, r: f32, g: f32, b: f32, a: f32);
     fn clear_depth(&self, depth: f32);
     fn clear_stencil(&self, stencil: i32);

--- a/yage-gl/src/functions/glfunctions.rs
+++ b/yage-gl/src/functions/glfunctions.rs
@@ -18,9 +18,13 @@ pub trait GlFunctions {
     type GlUniformLocation;
     type GlFramebuffer;
     type GlRenderbuffer;
+    type GlTransformFeedback;
 
     fn clear_color(&self, r: f32, g: f32, b: f32, a: f32);
     fn clear(&self, bit: BufferBit);
+    fn clear_depth(&self, depth: f32);
+    fn clear_stencil(&self, stencil: i32);
+    // TODO: glClearBuffer - 4 variants...
 
     fn viewport(&self, x: i32, y: i32, width: i32, height: i32);
 
@@ -50,6 +54,9 @@ pub trait GlFunctions {
     fn create_vertex_array(&self) -> Self::GlVertexArray;
     fn bind_vertex_array(&self, vertex_array: Option<&Self::GlVertexArray>);
     fn delete_vertex_array(&self, vertex_array: &Self::GlVertexArray);
+
+    fn get_attrib_location(&self, program: &Self::GlProgram, name: &str) -> i32;
+    fn bind_attrib_location(&self, program: &Self::GlProgram, index: u32, name: &str);
     fn vertex_attrib_pointer(
         &self,
         index: u32,
@@ -99,7 +106,22 @@ pub trait GlFunctions {
         height: i32,
         border: i32,
         format: u32,
-        ty: u32,
+        type_: u32,
+        pixels: Option<&[u8]>,
+    );
+
+    #[allow(clippy::too_many_arguments)]
+    fn tex_image_3d(
+        &self,
+        target: u32,
+        level: i32,
+        internal_format: i32,
+        width: i32,
+        height: i32,
+        depth: i32,
+        border: i32,
+        format: u32,
+        type_: u32,
         pixels: Option<&[u8]>,
     );
 
@@ -145,6 +167,20 @@ pub trait GlFunctions {
         renderbuffer: Option<&Self::GlRenderbuffer>,
     );
     fn check_framebuffer_status(&self, target: u32) -> u32;
+    #[allow(clippy::too_many_arguments)]
+    fn blit_framebuffer(
+        &self,
+        src_x0: i32,
+        src_y0: i32,
+        src_x1: i32,
+        src_y1: i32,
+        dst_x0: i32,
+        dst_y0: i32,
+        dst_x1: i32,
+        dst_y1: i32,
+        mask: u32,
+        filter: u32,
+    );
 
     fn polygon_mode(&self, face: u32, mode: u32);
 
@@ -177,19 +213,25 @@ pub trait GlFunctions {
     fn read_buffer(&self, mode: u32);
     fn draw_buffers(&self, buffers: &[u32]);
 
-    // TODO!:
-    // texImage3D, cubemap,
-    // glClearBuffer, glClearStencil, glClearDepth
-    // glDrawBuffers
-    // glIsFramebuffer
-    // glBlitFramebuffer
-    // glIsBuffer
+    fn is_buffer(&self, buffer: &Self::GlBuffer) -> bool;
+    fn is_frambuffer(&self, framebuffer: &Self::GlFramebuffer) -> bool;
+    fn is_texture(&self, texture: &Self::GlTexture) -> bool;
+
+    fn finish(&self);
+    fn flush(&self);
+
+    fn create_transform_feedback(&self) -> Self::GlTransformFeedback;
+    // fn bind_transform_feedback(&self, target: u32, tf: Option<&Self::GlTransformFeedback>);
+    // fn bind_buffer_base(&self, target: u32, index: u32, buffer: Option<&Self::GlBuffer>);
+    // fn transform_feedback_varyings(
+    //     &self,
+    //     program: &WebGlProgram,
+    //     varyings: &[&str],
+    //     buffer_mode: u32,
+    // );
+
+    // TODO!!!:
+    // , cubemap,
     // get_parameter / GetIntegerv
-    // bindAttribLocation, getAttribLocation
-    // isTexture
-    // glFinish
-    //
-    // tf: createTransformFeedback,
-    // bindTransformFeedback, bindBufferBase
-    // transformFeedbackVaryings
+    // reorder based on quick reference sections...
 }

--- a/yage-gl/src/functions/glfunctions.rs
+++ b/yage-gl/src/functions/glfunctions.rs
@@ -125,7 +125,7 @@ pub trait GlFunctions {
         pixels: Option<&[u8]>,
     );
 
-    fn generate_mipmap(&self);
+    fn generate_mipmap(&self, target: u32);
 
     fn tex_parameteri(&self, target: u32, parameter: u32, value: i32);
 
@@ -220,7 +220,11 @@ pub trait GlFunctions {
     fn finish(&self);
     fn flush(&self);
 
-    fn create_transform_feedback(&self) -> Self::GlTransformFeedback;
+    fn get_parameter_i32(&self, parameter: u32) -> i32;
+
+    // TODO!: transform feeback (NOTE: create is implemented, but commented out)
+    // fn create_transform_feedback(&self) -> Self::GlTransformFeedback;
+    // fn delete_transform_feedback(&self, tf: Option<&WebGlTransformFeedback>);
     // fn bind_transform_feedback(&self, target: u32, tf: Option<&Self::GlTransformFeedback>);
     // fn bind_buffer_base(&self, target: u32, index: u32, buffer: Option<&Self::GlBuffer>);
     // fn transform_feedback_varyings(
@@ -229,9 +233,13 @@ pub trait GlFunctions {
     //     varyings: &[&str],
     //     buffer_mode: u32,
     // );
+    // fn begin_transform_feedback(&self, primitive_mode: u32);
+    // fn pause_transform_feedback(&self);
+    // fn resume_transform_feedback(&self);
+    // fn end_transform_feedback(&self);
+    // fn is_transform_feedback(&self, tf: Option<&WebGlTransformFeedback>) -> bool;
 
-    // TODO!!!:
-    // , cubemap,
+    // TODO!:
     // get_parameter / GetIntegerv
     // reorder based on quick reference sections...
 }

--- a/yage-gl/src/objects/buffer.rs
+++ b/yage-gl/src/objects/buffer.rs
@@ -1,11 +1,11 @@
-use crate::{GL, GlFunctions};
+use crate::{GlFunctions, GL};
 
 /// Wrapper around an OpenGL array or element array buffer.
 pub struct Buffer<'a> {
     gl: &'a GL,
     /// Target for use in `glBindBuffer`
     target: u32,
-    buffer_handle: <GL as GlFunctions>::GlBuffer,
+    handle: <GL as GlFunctions>::GlBuffer,
 }
 
 impl<'a> Buffer<'a> {
@@ -18,13 +18,13 @@ impl<'a> Buffer<'a> {
         Self {
             gl,
             target,
-            buffer_handle: gl.create_buffer()
+            handle: gl.create_buffer(),
         }
     }
 
     /// Getter for the OpenGL/WebGL handle
     pub fn handle(&self) -> &<GL as GlFunctions>::GlBuffer {
-        &self.buffer_handle
+        &self.handle
     }
 
     /// Creates the buffer object's data store.
@@ -51,7 +51,7 @@ impl<'a> Buffer<'a> {
 
     /// Binds the buffer.
     pub fn bind(&self) {
-        self.gl.bind_buffer(self.target, Some(&self.buffer_handle));
+        self.gl.bind_buffer(self.target, Some(&self.handle));
     }
 
     /// Unbinds the buffer.
@@ -79,8 +79,8 @@ impl<'a> Buffer<'a> {
         stride: i32,
         offset: i32,
     ) {
-        self.gl.vertex_attrib_pointer(
-            index, size, data_type, normalized, stride, offset);
+        self.gl
+            .vertex_attrib_pointer(index, size, data_type, normalized, stride, offset);
         self.gl.enable_vertex_attrib_array(index);
     }
 
@@ -93,6 +93,6 @@ impl<'a> Buffer<'a> {
 
 impl<'a> Drop for Buffer<'a> {
     fn drop(&mut self) {
-        self.gl.delete_buffer(&self.buffer_handle);
+        self.gl.delete_buffer(&self.handle);
     }
 }

--- a/yage-gl/src/objects/buffer.rs
+++ b/yage-gl/src/objects/buffer.rs
@@ -1,6 +1,6 @@
 use crate::{GL, GlFunctions};
 
-/// Wrapper around an OpenGL array or element array buffer. 
+/// Wrapper around an OpenGL array or element array buffer.
 pub struct Buffer<'a> {
     gl: &'a GL,
     /// Target for use in `glBindBuffer`
@@ -9,8 +9,8 @@ pub struct Buffer<'a> {
 }
 
 impl<'a> Buffer<'a> {
-    /// Creates an empty buffer. 
-    /// 
+    /// Creates an empty buffer.
+    ///
     /// # Parameters
     /// - `gl`: GL context
     /// - `target`: must be a valid glenum for `glBindBuffer`
@@ -22,10 +22,15 @@ impl<'a> Buffer<'a> {
         }
     }
 
+    /// Getter for the OpenGL/WebGL handle
+    pub fn handle(&self) -> &<GL as GlFunctions>::GlBuffer {
+        &self.buffer_handle
+    }
+
     /// Creates the buffer object's data store.
-    /// 
+    ///
     /// Expects the buffer to be bound.
-    /// 
+    ///
     /// # Parameters
     /// - `data`: buffer data
     /// - `usage`: must be a valid glenum for `glBufferData`
@@ -34,9 +39,9 @@ impl<'a> Buffer<'a> {
     }
 
     /// Updates a subset of a buffer object's data store.
-    /// 
+    ///
     /// Expects the buffer to be bound.
-    /// 
+    ///
     /// # Parameters
     /// - `offset`: offset into the buffer object's data store in bytes
     /// - `data`: buffer data
@@ -55,9 +60,9 @@ impl<'a> Buffer<'a> {
     }
 
     /// Specifies the memory layout of the buffer for a binding point.
-    /// 
+    ///
     /// Expects the buffer to be bound.
-    /// 
+    ///
     /// # Parameters
     /// - `index` - Index of the vertex attribute that is to be setup and enabled.
     /// - `size` - Number of components per vertex attribute.

--- a/yage-gl/src/objects/framebuffer.rs
+++ b/yage-gl/src/objects/framebuffer.rs
@@ -23,6 +23,11 @@ impl<'a> Framebuffer<'a> {
         }
     }
 
+    /// Getter for the OpenGL/WebGL handle
+    pub fn handle(&self) -> &<GL as GlFunctions>::GlFramebuffer {
+        &self.handle
+    }
+
     /// Binds the framebuffer.
     pub fn bind(&self) {
         self.gl.bind_framebuffer(self.target, Some(&self.handle));

--- a/yage-gl/src/objects/framebuffer.rs
+++ b/yage-gl/src/objects/framebuffer.rs
@@ -3,6 +3,7 @@ use glenum;
 use crate::{GL, GlFunctions};
 
 /// Wrapper around an OpenGL frame buffer.
+// TODO!!: incomplete
 pub struct Framebuffer<'a> {
     gl: &'a GL,
     /// Target for use in `glBindFrameBuffer`

--- a/yage-gl/src/objects/framebuffer.rs
+++ b/yage-gl/src/objects/framebuffer.rs
@@ -1,0 +1,41 @@
+use glenum;
+
+use crate::{GL, GlFunctions};
+
+/// Wrapper around an OpenGL frame buffer.
+pub struct Framebuffer<'a> {
+    gl: &'a GL,
+    /// Target for use in `glBindFrameBuffer`
+    pub target: u32,
+    handle: <GL as GlFunctions>::GlFramebuffer,
+}
+
+impl<'a> Framebuffer<'a> {
+    /// Creates a framebuffer.
+    ///
+    /// # Parameters
+    /// - `gl`: GL context
+    pub fn new(gl: &'a GL) -> Self {
+        Self {
+            gl,
+            target: glenum::Buffers::Framebuffer as _,
+            handle: gl.create_framebuffer()
+        }
+    }
+
+    /// Binds the framebuffer.
+    pub fn bind(&self) {
+        self.gl.bind_framebuffer(self.target, Some(&self.handle));
+    }
+
+    /// Unbinds the framebuffer.
+    pub fn unbind(&self) {
+        self.gl.bind_framebuffer(self.target, None);
+    }
+}
+
+impl<'a> Drop for Framebuffer<'a> {
+    fn drop(&mut self) {
+        self.gl.delete_framebuffer(&self.handle);
+    }
+}

--- a/yage-gl/src/objects/mod.rs
+++ b/yage-gl/src/objects/mod.rs
@@ -9,3 +9,9 @@ pub use program::*;
 
 mod texture;
 pub use texture::*;
+
+mod framebuffer;
+pub use framebuffer::*;
+
+mod renderbuffer;
+pub use renderbuffer::*;

--- a/yage-gl/src/objects/program.rs
+++ b/yage-gl/src/objects/program.rs
@@ -85,6 +85,11 @@ impl<'a> Program<'a> {
         lines.join("\n")
     }
 
+    /// Getter for the OpenGL/WebGL handle
+    pub fn handle(&self) -> &<GL as GlFunctions>::GlProgram {
+        &self.program_handle
+    }
+
     /// activate the shader
     pub fn use_program(&self) {
         self.gl.use_program(Some(&self.program_handle))
@@ -120,7 +125,7 @@ impl<'a> Program<'a> {
     /// get uniform location with caching
     pub fn uniform_location(&mut self, name: &'static str) -> <GL as GlFunctions>::GlUniformLocation {
         if let Some(loc) = self.uniform_location_cache.get(name) {
-            #[allow(clippy::clone_on_copy)] // the type is only `Copy` on OpenGL, not WebGL 
+            #[allow(clippy::clone_on_copy)] // the type is only `Copy` on OpenGL, not WebGL
             return loc.clone();
         }
 
@@ -130,10 +135,10 @@ impl<'a> Program<'a> {
         //     // TODO!: trace!
         //     println!("uniform '{}' unknown for shader {:?}", name, self.id);
         // }
-        #[allow(clippy::clone_on_copy)] // the type is only `Copy` on OpenGL, not WebGL 
+        #[allow(clippy::clone_on_copy)] // the type is only `Copy` on OpenGL, not WebGL
         self.uniform_location_cache.insert(name, loc.clone());
         loc
-    } 
+    }
 
     /// utility function for checking shader compilation errors.
     fn check_compile_errors(gl: &GL, shader: &<GL as GlFunctions>::GlShader, type_: &str) {
@@ -141,7 +146,7 @@ impl<'a> Program<'a> {
         let log_type = if success == 1 { "WARNING" } else { "ERROR" };
         let info_log = gl.get_shader_info_log(shader);
         if info_log.is_empty() { return }
-        panic!("{}::SHADER_COMPILATION_{} of type: {}\n{}", 
+        panic!("{}::SHADER_COMPILATION_{} of type: {}\n{}",
             log_type, log_type, type_, info_log);
     }
 

--- a/yage-gl/src/objects/program.rs
+++ b/yage-gl/src/objects/program.rs
@@ -7,21 +7,28 @@ use cgmath::{Matrix4, Vector3, Vector4};
 
 // use log::{warn, trace};
 
-use crate::{GL, GlFunctions};
+use crate::{GlFunctions, GL};
 
 /// Wrapper object for OpenGL Programs.
 pub struct Program<'a> {
     gl: &'a GL,
-    program_handle: <GL as GlFunctions>::GlProgram,
-    uniform_location_cache: HashMap<&'static str, <GL as GlFunctions>::GlUniformLocation>
+    handle: <GL as GlFunctions>::GlProgram,
+    uniform_location_cache: HashMap<&'static str, <GL as GlFunctions>::GlUniformLocation>,
 }
 
 impl<'a> Program<'a> {
     /// Creates program from vertex and fragment shader paths and preprocessor defines.
-    pub fn from_file(gl: &'a GL, vertex_path: &str, fragment_path: &str, defines: &[String]) -> Program<'a> {
+    pub fn from_file(
+        gl: &'a GL,
+        vertex_path: &str,
+        fragment_path: &str,
+        defines: &[String],
+    ) -> Program<'a> {
         // retrieve the vertex/fragment source code from filesystem
-        let mut v_shader_file = File::open(vertex_path).unwrap_or_else(|_| panic!("Failed to open {}", vertex_path));
-        let mut f_shader_file = File::open(fragment_path).unwrap_or_else(|_| panic!("Failed to open {}", fragment_path));
+        let mut v_shader_file =
+            File::open(vertex_path).unwrap_or_else(|_| panic!("Failed to open {}", vertex_path));
+        let mut f_shader_file = File::open(fragment_path)
+            .unwrap_or_else(|_| panic!("Failed to open {}", fragment_path));
         let mut vertex_code = String::new();
         let mut fragment_code = String::new();
         v_shader_file
@@ -35,7 +42,12 @@ impl<'a> Program<'a> {
     }
 
     /// Creates program from vertex and fragment shader sources and preprocessor defines.
-    pub fn from_source(gl: &'a GL, vertex_code: &str, fragment_code: &str, defines: &[String]) -> Program<'a> {
+    pub fn from_source(
+        gl: &'a GL,
+        vertex_code: &str,
+        fragment_code: &str,
+        defines: &[String],
+    ) -> Program<'a> {
         let vertex_code = Self::add_defines(vertex_code, defines);
         let fragment_code = Self::add_defines(fragment_code, defines);
 
@@ -51,19 +63,19 @@ impl<'a> Program<'a> {
         gl.compile_shader(&fragment);
         Self::check_compile_errors(gl, &fragment, "FRAGMENT");
         // shader Program
-        let program_handle = gl.create_program();
-        gl.attach_shader(&program_handle, &vertex);
-        gl.attach_shader(&program_handle, &fragment);
-        gl.link_program(&program_handle);
-        Self::check_link_errors(gl, &program_handle);
+        let handle = gl.create_program();
+        gl.attach_shader(&handle, &vertex);
+        gl.attach_shader(&handle, &fragment);
+        gl.link_program(&handle);
+        Self::check_link_errors(gl, &handle);
         // delete the shaders as they're linked into our program now and no longer necessary
         gl.delete_shader(&vertex);
         gl.delete_shader(&fragment);
 
         Self {
-            program_handle,
+            handle,
             gl,
-            uniform_location_cache: HashMap::new()
+            uniform_location_cache: HashMap::new(),
         }
     }
 
@@ -71,15 +83,15 @@ impl<'a> Program<'a> {
     fn add_defines(source: &str, defines: &[String]) -> String {
         // insert preprocessor defines after #version if exists
         // (#version must occur before any other statement in the program)
-        let defines = defines.iter()
+        let defines = defines
+            .iter()
             .map(|define| format!("#define {}", define))
             .collect::<Vec<_>>()
             .join("\n");
         let mut lines: Vec<_> = source.lines().collect();
         if let Some(version_line) = lines.iter().position(|l| l.starts_with("#version")) {
-            lines.insert(version_line+1, &defines);
-        }
-        else {
+            lines.insert(version_line + 1, &defines);
+        } else {
             lines.insert(0, &defines);
         }
         lines.join("\n")
@@ -87,12 +99,12 @@ impl<'a> Program<'a> {
 
     /// Getter for the OpenGL/WebGL handle
     pub fn handle(&self) -> &<GL as GlFunctions>::GlProgram {
-        &self.program_handle
+        &self.handle
     }
 
     /// activate the shader
     pub fn use_program(&self) {
-        self.gl.use_program(Some(&self.program_handle))
+        self.gl.use_program(Some(&self.handle))
     }
 
     // uniform setting functions
@@ -106,16 +118,30 @@ impl<'a> Program<'a> {
     pub fn set_float(&self, location: &<GL as GlFunctions>::GlUniformLocation, value: f32) {
         self.gl.uniform_1f(location, value);
     }
-    pub fn set_vector3(&self, location: &<GL as GlFunctions>::GlUniformLocation, value: &Vector3<f32>) {
+    pub fn set_vector3(
+        &self,
+        location: &<GL as GlFunctions>::GlUniformLocation,
+        value: &Vector3<f32>,
+    ) {
         self.gl.uniform_3fv(location, value.as_ref());
     }
-    pub fn set_vector4(&self, location: &<GL as GlFunctions>::GlUniformLocation, value: &Vector4<f32>) {
+    pub fn set_vector4(
+        &self,
+        location: &<GL as GlFunctions>::GlUniformLocation,
+        value: &Vector4<f32>,
+    ) {
         self.gl.uniform_4fv(location, value.as_ref());
     }
     pub fn set_vec2(&self, location: &<GL as GlFunctions>::GlUniformLocation, x: f32, y: f32) {
         self.gl.uniform_2f(location, x, y);
     }
-    pub fn set_vec3(&self, location: &<GL as GlFunctions>::GlUniformLocation, x: f32, y: f32, z: f32) {
+    pub fn set_vec3(
+        &self,
+        location: &<GL as GlFunctions>::GlUniformLocation,
+        x: f32,
+        y: f32,
+        z: f32,
+    ) {
         self.gl.uniform_3f(location, x, y, z);
     }
     pub fn set_mat4(&self, location: &<GL as GlFunctions>::GlUniformLocation, mat: &Matrix4<f32>) {
@@ -123,13 +149,16 @@ impl<'a> Program<'a> {
     }
 
     /// get uniform location with caching
-    pub fn uniform_location(&mut self, name: &'static str) -> <GL as GlFunctions>::GlUniformLocation {
+    pub fn uniform_location(
+        &mut self,
+        name: &'static str,
+    ) -> <GL as GlFunctions>::GlUniformLocation {
         if let Some(loc) = self.uniform_location_cache.get(name) {
             #[allow(clippy::clone_on_copy)] // the type is only `Copy` on OpenGL, not WebGL
             return loc.clone();
         }
 
-        let loc = self.gl.get_uniform_location(&self.program_handle, name);
+        let loc = self.gl.get_uniform_location(&self.handle, name);
         // TODO!!: how to check null/-1 properly depending on WebGL/OpenGL??
         // if loc == -1 {
         //     // TODO!: trace!
@@ -145,9 +174,13 @@ impl<'a> Program<'a> {
         let success = gl.get_shader_parameter(shader, glenum::ShaderParameter::CompileStatus as _);
         let log_type = if success == 1 { "WARNING" } else { "ERROR" };
         let info_log = gl.get_shader_info_log(shader);
-        if info_log.is_empty() { return }
-        panic!("{}::SHADER_COMPILATION_{} of type: {}\n{}",
-            log_type, log_type, type_, info_log);
+        if info_log.is_empty() {
+            return;
+        }
+        panic!(
+            "{}::SHADER_COMPILATION_{} of type: {}\n{}",
+            log_type, log_type, type_, info_log
+        );
     }
 
     /// utility function for checking program linking errors.
@@ -155,9 +188,10 @@ impl<'a> Program<'a> {
         let success = gl.get_program_parameter(program, glenum::ShaderParameter::LinkStatus as _);
         let log_type = if success == 1 { "WARNING" } else { "ERROR" };
         let info_log = gl.get_program_info_log(program);
-        if info_log.is_empty() { return }
+        if info_log.is_empty() {
+            return;
+        }
         // TODO!: warn!
-        println!("{}::PROGRAM_LINKING_{} \n{}",
-                    log_type, log_type, info_log);
+        println!("{}::PROGRAM_LINKING_{} \n{}", log_type, log_type, info_log);
     }
 }

--- a/yage-gl/src/objects/renderbuffer.rs
+++ b/yage-gl/src/objects/renderbuffer.rs
@@ -20,6 +20,11 @@ impl<'a> Renderbuffer<'a> {
         }
     }
 
+    /// Getter for the OpenGL/WebGL handle
+    pub fn handle(&self) -> &<GL as GlFunctions>::GlRenderbuffer {
+        &self.handle
+    }
+
     /// Binds the renderbuffer.
     pub fn bind(&self) {
         self.gl.bind_renderbuffer(glenum::Buffers::Renderbuffer as _, Some(&self.handle));

--- a/yage-gl/src/objects/renderbuffer.rs
+++ b/yage-gl/src/objects/renderbuffer.rs
@@ -1,0 +1,38 @@
+use glenum;
+
+use crate::{GL, GlFunctions};
+
+/// Wrapper around an OpenGL renderbuffer.
+pub struct Renderbuffer<'a> {
+    gl: &'a GL,
+    handle: <GL as GlFunctions>::GlRenderbuffer,
+}
+
+impl<'a> Renderbuffer<'a> {
+    /// Creates a renderbuffer.
+    ///
+    /// # Parameters
+    /// - `gl`: GL context
+    pub fn new(gl: &'a GL) -> Self {
+        Self {
+            gl,
+            handle: gl.create_renderbuffer()
+        }
+    }
+
+    /// Binds the renderbuffer.
+    pub fn bind(&self) {
+        self.gl.bind_renderbuffer(glenum::Buffers::Renderbuffer as _, Some(&self.handle));
+    }
+
+    /// Unbinds the renderbuffer.
+    pub fn unbind(&self) {
+        self.gl.bind_renderbuffer(glenum::Buffers::Renderbuffer as _, None);
+    }
+}
+
+impl<'a> Drop for Renderbuffer<'a> {
+    fn drop(&mut self) {
+        self.gl.delete_renderbuffer(&self.handle);
+    }
+}

--- a/yage-gl/src/objects/renderbuffer.rs
+++ b/yage-gl/src/objects/renderbuffer.rs
@@ -3,6 +3,7 @@ use glenum;
 use crate::{GL, GlFunctions};
 
 /// Wrapper around an OpenGL renderbuffer.
+// TODO!!: incomplete
 pub struct Renderbuffer<'a> {
     gl: &'a GL,
     handle: <GL as GlFunctions>::GlRenderbuffer,

--- a/yage-gl/src/objects/texture.rs
+++ b/yage-gl/src/objects/texture.rs
@@ -47,6 +47,7 @@ impl<'a> Texture<'a> {
         self.gl.tex_parameteri(self.target, glenum::TextureParameter::TextureMinFilter as _, min);
     }
 
+    // TODO!!: Option<wrap_r> or seperate 3D texture object?
     /// Sets the texture object's wrapping function for s and t coordinates.
     ///
     /// # Parameters:
@@ -83,6 +84,10 @@ impl<'a> Texture<'a> {
         self.gl.tex_image_2d(
             self.target, level, internal_format,
             width, height, border, format, ty, pixels);
+    }
+
+    pub fn generate_mipmap(&self) {
+        self.gl.generate_mipmap(self.target);
     }
 }
 

--- a/yage-gl/src/objects/texture.rs
+++ b/yage-gl/src/objects/texture.rs
@@ -1,6 +1,6 @@
 use crate::{GL, GlFunctions};
 
-/// Wrapper around an OpenGL texture. 
+/// Wrapper around an OpenGL texture.
 pub struct Texture<'a> {
     gl: &'a GL,
     /// Target for use in `glBindTexture`
@@ -9,8 +9,8 @@ pub struct Texture<'a> {
 }
 
 impl<'a> Texture<'a> {
-    /// Creates an texture. 
-    /// 
+    /// Creates an texture.
+    ///
     /// # Parameters
     /// - `gl`: GL context
     /// - `target`: must be a valid glenum for `glBindTexture`
@@ -20,6 +20,11 @@ impl<'a> Texture<'a> {
             target,
             texture_handle: gl.create_texture()
         }
+    }
+
+    /// Getter for the OpenGL/WebGL handle
+    pub fn handle(&self) -> &<GL as GlFunctions>::GlTexture {
+        &self.texture_handle
     }
 
     /// Binds the texture.
@@ -33,7 +38,7 @@ impl<'a> Texture<'a> {
     }
 
     /// Sets the texture object's magnification and minification filter.
-    /// 
+    ///
     /// # Parameters:
     /// - `mag`: Value for the TEXTURE_MAG_FILTER parameter
     /// - `min`: Value for the TEXTURE_MIN_FILTER parameter
@@ -43,7 +48,7 @@ impl<'a> Texture<'a> {
     }
 
     /// Sets the texture object's wrapping function for s and t coordinates.
-    /// 
+    ///
     /// # Parameters:
     /// - `wrap_s`: Value for the TEXTURE_WRAP_S parameter
     /// - `wrap_t`: Value for the TEXTURE_WRAP_T parameter
@@ -53,22 +58,22 @@ impl<'a> Texture<'a> {
     }
 
     /// Pass image data to the texture object.
-    /// 
+    ///
     /// # Parameters:
     /// - `level`: level-of-detail number
-    /// - `internal_format`: 
-    /// - `width`: 
-    /// - `height`: 
-    /// - `border`: 
-    /// - `format`: 
+    /// - `internal_format`:
+    /// - `width`:
+    /// - `height`:
+    /// - `border`:
+    /// - `format`:
     /// - `ty`: type
     /// - `pixels`: pixel data
     #[allow(clippy::too_many_arguments)]
     pub fn image_2d(
-        &self, 
-        level: i32, 
-        internal_format: i32, 
-        width: i32, 
+        &self,
+        level: i32,
+        internal_format: i32,
+        width: i32,
         height: i32,
         border: i32,
         format: u32,
@@ -76,7 +81,7 @@ impl<'a> Texture<'a> {
         pixels: Option<&[u8]>
     ) {
         self.gl.tex_image_2d(
-            self.target, level, internal_format, 
+            self.target, level, internal_format,
             width, height, border, format, ty, pixels);
     }
 }

--- a/yage-gl/src/objects/texture.rs
+++ b/yage-gl/src/objects/texture.rs
@@ -1,11 +1,11 @@
-use crate::{GL, GlFunctions};
+use crate::{GlFunctions, GL};
 
 /// Wrapper around an OpenGL texture.
 pub struct Texture<'a> {
     gl: &'a GL,
     /// Target for use in `glBindTexture`
     target: u32,
-    texture_handle: <GL as GlFunctions>::GlTexture,
+    handle: <GL as GlFunctions>::GlTexture,
 }
 
 impl<'a> Texture<'a> {
@@ -18,18 +18,18 @@ impl<'a> Texture<'a> {
         Self {
             gl,
             target,
-            texture_handle: gl.create_texture()
+            handle: gl.create_texture(),
         }
     }
 
     /// Getter for the OpenGL/WebGL handle
     pub fn handle(&self) -> &<GL as GlFunctions>::GlTexture {
-        &self.texture_handle
+        &self.handle
     }
 
     /// Binds the texture.
     pub fn bind(&self) {
-        self.gl.bind_texture(self.target, Some(&self.texture_handle));
+        self.gl.bind_texture(self.target, Some(&self.handle));
     }
 
     /// Unbinds the texture.
@@ -43,8 +43,16 @@ impl<'a> Texture<'a> {
     /// - `mag`: Value for the TEXTURE_MAG_FILTER parameter
     /// - `min`: Value for the TEXTURE_MIN_FILTER parameter
     pub fn filter(&self, mag: i32, min: i32) {
-        self.gl.tex_parameteri(self.target, glenum::TextureParameter::TextureMagFilter as _, mag);
-        self.gl.tex_parameteri(self.target, glenum::TextureParameter::TextureMinFilter as _, min);
+        self.gl.tex_parameteri(
+            self.target,
+            glenum::TextureParameter::TextureMagFilter as _,
+            mag,
+        );
+        self.gl.tex_parameteri(
+            self.target,
+            glenum::TextureParameter::TextureMinFilter as _,
+            min,
+        );
     }
 
     // TODO!!: Option<wrap_r> or seperate 3D texture object?
@@ -54,8 +62,16 @@ impl<'a> Texture<'a> {
     /// - `wrap_s`: Value for the TEXTURE_WRAP_S parameter
     /// - `wrap_t`: Value for the TEXTURE_WRAP_T parameter
     pub fn wrap(&self, wrap_s: i32, wrap_t: i32) {
-        self.gl.tex_parameteri(self.target, glenum::TextureParameter::TextureWrapS as _, wrap_s);
-        self.gl.tex_parameteri(self.target, glenum::TextureParameter::TextureWrapT as _, wrap_t);
+        self.gl.tex_parameteri(
+            self.target,
+            glenum::TextureParameter::TextureWrapS as _,
+            wrap_s,
+        );
+        self.gl.tex_parameteri(
+            self.target,
+            glenum::TextureParameter::TextureWrapT as _,
+            wrap_t,
+        );
     }
 
     /// Pass image data to the texture object.
@@ -79,11 +95,19 @@ impl<'a> Texture<'a> {
         border: i32,
         format: u32,
         ty: u32,
-        pixels: Option<&[u8]>
+        pixels: Option<&[u8]>,
     ) {
         self.gl.tex_image_2d(
-            self.target, level, internal_format,
-            width, height, border, format, ty, pixels);
+            self.target,
+            level,
+            internal_format,
+            width,
+            height,
+            border,
+            format,
+            ty,
+            pixels,
+        );
     }
 
     pub fn generate_mipmap(&self) {
@@ -91,9 +115,8 @@ impl<'a> Texture<'a> {
     }
 }
 
-
 impl<'a> Drop for Texture<'a> {
     fn drop(&mut self) {
-        self.gl.delete_texture(&self.texture_handle);
+        self.gl.delete_texture(&self.handle);
     }
 }

--- a/yage-gl/src/objects/vertex_array.rs
+++ b/yage-gl/src/objects/vertex_array.rs
@@ -7,8 +7,8 @@ pub struct VertexArray<'a> {
 }
 
 impl<'a> VertexArray<'a> {
-    /// Creates a vertex array. 
-    /// 
+    /// Creates a vertex array.
+    ///
     /// # Parameters
     /// - `gl`: GL context
     pub fn new(gl: &'a GL) -> Self {
@@ -17,7 +17,12 @@ impl<'a> VertexArray<'a> {
             array_handle: gl.create_vertex_array()
         }
     }
-    
+
+    /// Getter for the OpenGL/WebGL handle
+    pub fn handle(&self) -> &<GL as GlFunctions>::GlVertexArray {
+        &self.array_handle
+    }
+
     /// Binds the vertex array.
     pub fn bind(&self) {
         self.gl.bind_vertex_array(Some(&self.array_handle));


### PR DESCRIPTION
* Finishes `yage_gl::functions` for now (...still mostly untested and one or two 'important' things are unimplemented)
  - reorders all functions into logical groups -> big diff
* Stubs a few more objects (framebuffer, renderbuffer)
* adds `handle()` method to all objects