### PR TITLE
[WIP] use Rc<GL> instead of lifetimes

### DIFF
--- a/yage-gl/src/objects/buffer.rs
+++ b/yage-gl/src/objects/buffer.rs
@@ -1,22 +1,24 @@
+use std::rc::Rc;
+
 use crate::{GlFunctions, GL};
 
 /// Wrapper around an OpenGL array or element array buffer.
-pub struct Buffer<'a> {
-    gl: &'a GL,
+pub struct Buffer {
+    gl: Rc<GL>,
     /// Target for use in `glBindBuffer`
     target: u32,
     handle: <GL as GlFunctions>::GlBuffer,
 }
 
-impl<'a> Buffer<'a> {
+impl Buffer {
     /// Creates an empty buffer.
     ///
     /// # Parameters
     /// - `gl`: GL context
     /// - `target`: must be a valid glenum for `glBindBuffer`
-    pub fn new(gl: &'a GL, target: u32) -> Self {
+    pub fn new(gl: &Rc<GL>, target: u32) -> Self {
         Self {
-            gl,
+            gl: gl.clone(),
             target,
             handle: gl.create_buffer(),
         }
@@ -91,7 +93,7 @@ impl<'a> Buffer<'a> {
     }
 }
 
-impl<'a> Drop for Buffer<'a> {
+impl Drop for Buffer {
     fn drop(&mut self) {
         self.gl.delete_buffer(&self.handle);
     }

--- a/yage-gl/src/objects/vertex_array.rs
+++ b/yage-gl/src/objects/vertex_array.rs
@@ -1,20 +1,22 @@
-use crate::{GL, GlFunctions};
+use std::rc::Rc;
+
+use crate::{GlFunctions, GL};
 
 /// Wrapper around an OpenGL vertex array.
-pub struct VertexArray<'a> {
-    gl: &'a GL,
+pub struct VertexArray {
+    gl: Rc<GL>,
     array_handle: <GL as GlFunctions>::GlVertexArray,
 }
 
-impl<'a> VertexArray<'a> {
+impl VertexArray {
     /// Creates a vertex array.
     ///
     /// # Parameters
     /// - `gl`: GL context
-    pub fn new(gl: &'a GL) -> Self {
+    pub fn new(gl: &Rc<GL>) -> Self {
         Self {
-            gl,
-            array_handle: gl.create_vertex_array()
+            gl: gl.clone(),
+            array_handle: gl.create_vertex_array(),
         }
     }
 
@@ -34,7 +36,7 @@ impl<'a> VertexArray<'a> {
     }
 }
 
-impl<'a> Drop for VertexArray<'a> {
+impl Drop for VertexArray {
     fn drop(&mut self) {
         self.gl.delete_vertex_array(&self.array_handle);
     }


### PR DESCRIPTION
WIP because I only tried it with Buffer and VertexArray so far. But `gltf-viewer` compiles and runs fine now: https://github.com/bwasty/gltf-viewer/compare/yage.